### PR TITLE
Use Postgres DAL for daily summaries and strength logs

### DIFF
--- a/pete_e/core/lift_log.py
+++ b/pete_e/core/lift_log.py
@@ -14,31 +14,16 @@ def append_log_entry(
     rir: int | None = None,
     log_date: str | None = None,
 ) -> None:
-    """
-    Appends a new entry to the log for a given exercise using the provided DAL.
-    """
-    # Use the DAL to load the data, instead of reading the file directly
-    log = dal.load_lift_log()
-    key = str(exercise_id)
-    if key not in log:
-        log[key] = []
-
-    entry = {
-        "date": log_date or date.today().isoformat(),
-        "weight": weight,
-        "reps": reps,
-        "sets": sets,
-    }
-    if rir is not None:
-        entry["rir"] = rir
-
-    log[key].append(entry)
-
-    # Keep sorted by date
-    log[key] = sorted(log[key], key=lambda x: x["date"])
-    
-    # Use the DAL to save the data
-    dal.save_lift_log(log)
+    """Persist a strength training entry using the DAL."""
+    log_dt = date.fromisoformat(log_date) if log_date else date.today()
+    for _ in range(sets):
+        dal.save_strength_log_entry(
+            exercise_id=exercise_id,
+            log_date=log_dt,
+            reps=reps,
+            weight_kg=weight,
+            rir=rir,
+        )
 
 
 def get_history_for_exercise(

--- a/pete_e/data_access/dal.py
+++ b/pete_e/data_access/dal.py
@@ -22,6 +22,18 @@ class DataAccessLayer(ABC):
         pass
 
     @abstractmethod
+    def save_strength_log_entry(
+        self,
+        exercise_id: int,
+        log_date: date,
+        reps: int,
+        weight_kg: float,
+        rir: Optional[float] = None,
+    ) -> None:
+        """Persists a single strength training set."""
+        pass
+
+    @abstractmethod
     def load_history(self) -> Dict[str, Any]:
         """Loads the consolidated history file."""
         pass

--- a/pete_e/data_access/postgres_dal.py
+++ b/pete_e/data_access/postgres_dal.py
@@ -5,7 +5,6 @@ This class handles all communication with the PostgreSQL database using a
 robust connection pool for efficiency and reliability.
 """
 
-import json
 from datetime import date
 from typing import Any, Dict, List, Optional
 
@@ -67,11 +66,13 @@ class PostgresDal(DataAccessLayer):
         return lift_log
 
     def save_daily_summary(self, summary: Dict[str, Any], day: date) -> None:
-        """Saves a daily summary to the daily_summary table using an UPSERT operation."""
-        log_utils.log_message(f"[PostgresDal] Saving daily summary for {day.isoformat()}", "INFO")
+        """Upserts a row into ``daily_summary``."""
+        log_utils.log_message(
+            f"[PostgresDal] Saving daily summary for {day.isoformat()}", "INFO"
+        )
         withings = summary.get("withings", {})
         apple = summary.get("apple", {})
-        sleep = apple.get("sleep_minutes", {})
+        sleep = apple.get("sleep", {})
 
         try:
             with pool.connection() as conn:
@@ -79,56 +80,164 @@ class PostgresDal(DataAccessLayer):
                     cur.execute(
                         """
                         INSERT INTO daily_summary (
-                            "date", weight_kg, body_fat_pct, steps, exercise_minutes,
-                            calories_active, calories_resting, stand_minutes, distance_m,
-                            hr_resting, hr_avg, hr_max, hr_min, sleep_asleep_minutes, sleep_details
-                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                        ON CONFLICT ("date") DO UPDATE SET
-                            weight_kg = EXCLUDED.weight_kg, body_fat_pct = EXCLUDED.body_fat_pct,
-                            steps = EXCLUDED.steps, exercise_minutes = EXCLUDED.exercise_minutes,
-                            calories_active = EXCLUDED.calories_active, calories_resting = EXCLUDED.calories_resting,
-                            stand_minutes = EXCLUDED.stand_minutes, distance_m = EXCLUDED.distance_m,
-                            hr_resting = EXCLUDED.hr_resting, hr_avg = EXCLUDED.hr_avg,
-                            hr_max = EXCLUDED.hr_max, hr_min = EXCLUDED.hr_min,
+                            summary_date, weight_kg, body_fat_pct, muscle_mass_kg, water_pct,
+                            steps, exercise_minutes, calories_active, calories_resting, stand_minutes,
+                            distance_m, hr_resting, hr_avg, hr_max, hr_min,
+                            sleep_total_minutes, sleep_asleep_minutes, sleep_rem_minutes,
+                            sleep_deep_minutes, sleep_core_minutes, sleep_awake_minutes
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        ON CONFLICT (summary_date) DO UPDATE SET
+                            weight_kg = EXCLUDED.weight_kg,
+                            body_fat_pct = EXCLUDED.body_fat_pct,
+                            muscle_mass_kg = EXCLUDED.muscle_mass_kg,
+                            water_pct = EXCLUDED.water_pct,
+                            steps = EXCLUDED.steps,
+                            exercise_minutes = EXCLUDED.exercise_minutes,
+                            calories_active = EXCLUDED.calories_active,
+                            calories_resting = EXCLUDED.calories_resting,
+                            stand_minutes = EXCLUDED.stand_minutes,
+                            distance_m = EXCLUDED.distance_m,
+                            hr_resting = EXCLUDED.hr_resting,
+                            hr_avg = EXCLUDED.hr_avg,
+                            hr_max = EXCLUDED.hr_max,
+                            hr_min = EXCLUDED.hr_min,
+                            sleep_total_minutes = EXCLUDED.sleep_total_minutes,
                             sleep_asleep_minutes = EXCLUDED.sleep_asleep_minutes,
-                            sleep_details = EXCLUDED.sleep_details;
+                            sleep_rem_minutes = EXCLUDED.sleep_rem_minutes,
+                            sleep_deep_minutes = EXCLUDED.sleep_deep_minutes,
+                            sleep_core_minutes = EXCLUDED.sleep_core_minutes,
+                            sleep_awake_minutes = EXCLUDED.sleep_awake_minutes;
                         """,
                         (
                             day,
-                            withings.get("weight_kg"),
-                            withings.get("body_fat_pct"),
+                            withings.get("weight"),
+                            withings.get("fat_percent"),
+                            withings.get("muscle_mass"),
+                            withings.get("water_percent"),
                             apple.get("steps"),
                             apple.get("exercise_minutes"),
-                            apple.get("calories_active"),
-                            apple.get("calories_resting"),
+                            apple.get("calories", {}).get("active"),
+                            apple.get("calories", {}).get("resting"),
                             apple.get("stand_minutes"),
                             apple.get("distance_m"),
-                            apple.get("hr_resting"),
-                            apple.get("hr_avg"),
-                            apple.get("hr_max"),
-                            apple.get("hr_min"),
+                            apple.get("heart_rate", {}).get("resting"),
+                            apple.get("heart_rate", {}).get("avg"),
+                            apple.get("heart_rate", {}).get("max"),
+                            apple.get("heart_rate", {}).get("min"),
+                            sleep.get("in_bed"),
                             sleep.get("asleep"),
-                            json.dumps(sleep) if sleep else None,
+                            sleep.get("rem"),
+                            sleep.get("deep"),
+                            sleep.get("core"),
+                            sleep.get("awake"),
                         ),
                     )
         except Exception as e:
-            log_utils.log_message(f"Error saving daily summary to Postgres for {day}: {e}", "ERROR")
+            log_utils.log_message(
+                f"Error saving daily summary to Postgres for {day}: {e}", "ERROR"
+            )
 
     # --- Other DAL methods from your implementation ---
     # (I've omitted them for brevity but they should remain as you wrote them,
     # just ensure they also use `with pool.connection() as conn:`)
 
     def save_lift_log(self, log: Dict[str, Any]) -> None:
-        log_utils.log_message("[PostgresDal] save_lift_log is a no-op in this implementation.", "WARN")
-        pass
+        log_utils.log_message(
+            "[PostgresDal] save_lift_log deprecated; use save_strength_log_entry",
+            "WARN",
+        )
+
+    def save_strength_log_entry(
+        self,
+        exercise_id: int,
+        log_date: date,
+        reps: int,
+        weight_kg: float,
+        rir: Optional[float] = None,
+    ) -> None:
+        """Insert a single set into ``strength_log``."""
+        try:
+            with pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO strength_log (
+                            summary_date, exercise_id, reps, weight_kg, rir
+                        ) VALUES (%s, %s, %s, %s, %s);
+                        """,
+                        (log_date, exercise_id, reps, weight_kg, rir),
+                    )
+        except Exception as e:
+            log_utils.log_message(
+                f"Error saving strength log entry for {log_date}: {e}", "ERROR"
+            )
 
     def load_history(self) -> Dict[str, Any]:
-        # This implementation remains the same as in your file.
-        pass
-    
+        """Return all rows from ``daily_summary`` keyed by ISO date."""
+        out: Dict[str, Any] = {}
+        try:
+            with pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT * FROM daily_summary ORDER BY summary_date ASC;"
+                    )
+                    for row in cur.fetchall():
+                        day = row["summary_date"].isoformat()
+                        out[day] = {
+                            "withings": {
+                                "weight": float(row["weight_kg"])
+                                if row["weight_kg"] is not None
+                                else None,
+                                "fat_percent": float(row["body_fat_pct"])
+                                if row["body_fat_pct"] is not None
+                                else None,
+                                "muscle_mass": float(row["muscle_mass_kg"])
+                                if row["muscle_mass_kg"] is not None
+                                else None,
+                                "water_percent": float(row["water_pct"])
+                                if row["water_pct"] is not None
+                                else None,
+                            },
+                            "apple": {
+                                "steps": row["steps"],
+                                "exercise_minutes": row["exercise_minutes"],
+                                "calories": {
+                                    "active": row["calories_active"],
+                                    "resting": row["calories_resting"],
+                                },
+                                "stand_minutes": row["stand_minutes"],
+                                "distance_m": row["distance_m"],
+                                "heart_rate": {
+                                    "resting": row["hr_resting"],
+                                    "avg": row["hr_avg"],
+                                    "max": row["hr_max"],
+                                    "min": row["hr_min"],
+                                },
+                                "sleep": {
+                                    "in_bed": row["sleep_total_minutes"],
+                                    "asleep": row["sleep_asleep_minutes"],
+                                    "rem": row["sleep_rem_minutes"],
+                                    "deep": row["sleep_deep_minutes"],
+                                    "core": row["sleep_core_minutes"],
+                                    "awake": row["sleep_awake_minutes"],
+                                },
+                            },
+                        }
+        except Exception as e:
+            log_utils.log_message(
+                f"Error loading daily history from Postgres: {e}", "ERROR"
+            )
+        return out
+
     def save_history(self, history: Dict[str, Any]) -> None:
-        # This implementation remains the same as in your file.
-        pass
+        """Persist provided history by upserting each summary."""
+        for day_str, data in history.items():
+            try:
+                self.save_daily_summary(data, date.fromisoformat(day_str))
+            except Exception as e:
+                log_utils.log_message(
+                    f"Error saving history for {day_str}: {e}", "ERROR"
+                )
 
     def load_body_age(self) -> Dict[str, Any]:
         # This implementation remains the same as in your file.


### PR DESCRIPTION
## Summary
- add DAL method for saving individual strength sets
- implement Postgres DAL to upsert daily summaries and strength sets
- refactor sync to persist metrics before logging workouts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5849268e4832fb8a37ef4b0ae14ff