### PR TITLE
Implement Apple Health export processing

### DIFF
--- a/pete_e/core/apple_client.py
+++ b/pete_e/core/apple_client.py
@@ -3,7 +3,16 @@ Apple Health client for Pete-E
 Refactored from write_apple.py – no legacy artefacts, returns clean dicts.
 """
 
-from datetime import date
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+from zipfile import ZipFile
+
+from pete_e.data_access.dal import DataAccessLayer
+from pete_e.infra import log_utils
 
 
 def clean_num(v, as_int: bool = True):
@@ -72,3 +81,249 @@ def get_apple_summary(payload: dict) -> dict:
             "rem": clean_num(payload.get("rem")),
         },
     }
+
+
+def process_apple_health_export(zip_path: str, dal: Optional[DataAccessLayer] = None) -> int:
+    """Process a zipped Apple Health export and persist the contained summaries.
+
+    Args:
+        zip_path: Path to the Apple Health export zip file.
+        dal: Optional data access layer. When ``None`` a :class:`PostgresDal`
+            instance is created on demand.
+
+    Returns:
+        Number of daily summaries that were written to the database.
+    """
+
+    archive_path = Path(zip_path)
+    if not archive_path.exists():
+        raise FileNotFoundError(f"Apple Health export not found: {zip_path}")
+
+    log_utils.log_message(
+        f"Processing Apple Health export '{archive_path.name}'", "INFO"
+    )
+
+    payloads: List[Dict[str, Any]] = []
+    with ZipFile(archive_path) as zf:
+        json_members = [
+            member
+            for member in zf.infolist()
+            if not member.is_dir() and member.filename.lower().endswith(".json")
+        ]
+
+        if not json_members:
+            raise ValueError(
+                "Apple Health export does not contain any JSON payloads to process."
+            )
+
+        for member in json_members:
+            try:
+                with zf.open(member) as fh:
+                    raw = fh.read().decode("utf-8", errors="ignore")
+                    loaded = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                log_utils.log_message(
+                    f"Skipping '{member.filename}' due to JSON decode error: {exc}",
+                    "WARN",
+                )
+                continue
+
+            payloads.extend(list(_iter_daily_payloads(loaded)))
+
+    if not payloads:
+        raise ValueError("No daily summaries were found in the Apple Health export.")
+
+    processed = 0
+    close_pool = None
+
+    if dal is None:
+        try:
+            from pete_e.data_access.postgres_dal import PostgresDal, close_pool as closer
+        except Exception as exc:  # pragma: no cover - import-time environment issues
+            log_utils.log_message(
+                f"Unable to initialise Postgres DAL for Apple ingestion: {exc}",
+                "ERROR",
+            )
+            raise
+
+        dal = PostgresDal()
+        close_pool = closer
+
+    try:
+        for payload in payloads:
+            normalised = _normalise_daily_payload(payload)
+            if not normalised:
+                continue
+
+            day, metrics = normalised
+            dal.save_apple_daily(day, metrics)
+            processed += 1
+            log_utils.log_message(
+                f"Saved Apple Health summary for {day.isoformat()}", "INFO"
+            )
+    finally:
+        if close_pool:
+            close_pool()
+
+    log_utils.log_message(
+        f"Processed {processed} Apple Health daily summaries from export.", "INFO"
+    )
+
+    return processed
+
+
+def _iter_daily_payloads(obj: Any) -> Iterator[Dict[str, Any]]:
+    """Yield candidate daily summary payloads from an arbitrary structure."""
+
+    if isinstance(obj, dict):
+        if any(key in obj for key in ("date", "day", "day_date")):
+            yield obj
+
+        for key in ("days", "entries", "data", "summaries"):
+            value = obj.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        yield from _iter_daily_payloads(item)
+        return
+
+    if isinstance(obj, list):
+        for item in obj:
+            if isinstance(item, dict):
+                yield from _iter_daily_payloads(item)
+
+
+def _parse_date(value: str) -> Optional[date]:
+    if not value:
+        return None
+
+    cleaned = value.strip()
+    for fmt in ("%Y-%m-%d", "%Y%m%d"):
+        try:
+            return datetime.strptime(cleaned[: len(fmt)], fmt).date()
+        except ValueError:
+            continue
+
+    if cleaned.endswith("Z"):
+        cleaned = cleaned[:-1] + "+00:00"
+
+    try:
+        return datetime.fromisoformat(cleaned).date()
+    except ValueError:
+        return None
+
+
+def _get_first(container: Dict[str, Any], *paths: Iterable[str]) -> Any:
+    for path in paths:
+        if isinstance(path, str):
+            value = container.get(path)
+        else:
+            value = container
+            for key in path:
+                if not isinstance(value, dict):
+                    value = None
+                    break
+                value = value.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _normalise_daily_payload(payload: Dict[str, Any]) -> Optional[Tuple[date, Dict[str, Any]]]:
+    day_value = (
+        payload.get("date")
+        or payload.get("day")
+        or payload.get("day_date")
+        or payload.get("summary_date")
+    )
+    day = _parse_date(day_value) if day_value else None
+
+    if not day:
+        log_utils.log_message(
+            "Skipping Apple payload with missing/invalid date field.", "WARN"
+        )
+        return None
+
+    # Handle nested calorie structures
+    calories_block = payload.get("calories")
+    if isinstance(calories_block, dict):
+        for key, alias in (
+            ("active", "calories_active"),
+            ("resting", "calories_resting"),
+            ("total", "calories_total"),
+        ):
+            if alias not in payload and key in calories_block:
+                payload[alias] = calories_block.get(key)
+
+    heart_block = payload.get("heart_rate")
+    if isinstance(heart_block, dict):
+        for key, alias in (
+            ("min", "hr_min"),
+            ("max", "hr_max"),
+            ("avg", "hr_avg"),
+            ("resting", "hr_resting"),
+        ):
+            if alias not in payload and key in heart_block:
+                payload[alias] = heart_block.get(key)
+
+    sleep_block: Dict[str, Any] = {}
+    for candidate in (payload.get("sleep_minutes"), payload.get("sleep")):
+        if isinstance(candidate, dict):
+            if "minutes" in candidate and isinstance(candidate["minutes"], dict):
+                sleep_block = candidate["minutes"]
+            else:
+                sleep_block = candidate
+            break
+
+    def sleep_val(*keys: Iterable[str]) -> Optional[int]:
+        value = _get_first(sleep_block, *keys)
+        return clean_num(value) if value is not None else None
+
+    distance_m = clean_num(
+        _get_first(
+            payload,
+            "distance_m",
+            ("distance", "meters"),
+            ("distance", "m"),
+        )
+    )
+    if distance_m is None:
+        distance_km = clean_num(
+            _get_first(payload, "distance_km", ("distance", "km")),
+            as_int=False,
+        )
+        if distance_km is not None:
+            distance_m = int(distance_km * 1000)
+
+    metrics = {
+        "steps": clean_num(_get_first(payload, "steps", ("activity", "steps"))),
+        "exercise_minutes": clean_num(
+            _get_first(payload, "exercise_minutes", ("activity", "exercise_minutes"))
+        ),
+        "calories_active": clean_num(payload.get("calories_active")),
+        "calories_resting": clean_num(payload.get("calories_resting")),
+        "calories_total": clean_num(payload.get("calories_total")),
+        "stand_minutes": clean_num(payload.get("stand_minutes")),
+        "distance_m": distance_m,
+        "hr_resting": clean_num(payload.get("hr_resting")),
+        "hr_avg": clean_num(payload.get("hr_avg")),
+        "hr_max": clean_num(payload.get("hr_max")),
+        "hr_min": clean_num(payload.get("hr_min")),
+        "sleep_total_minutes": sleep_val("in_bed", "total", "total_minutes"),
+        "sleep_asleep_minutes": sleep_val("asleep", "asleep_minutes"),
+        "sleep_rem_minutes": sleep_val("rem", "rem_minutes"),
+        "sleep_deep_minutes": sleep_val("deep", "deep_minutes"),
+        "sleep_core_minutes": sleep_val("core", "core_minutes", "light"),
+        "sleep_awake_minutes": sleep_val("awake", "awake_minutes"),
+    }
+
+    # Derive total sleep if not provided but asleep and awake are available.
+    if metrics["sleep_total_minutes"] is None:
+        asleep = metrics["sleep_asleep_minutes"]
+        awake = metrics["sleep_awake_minutes"]
+        if asleep is not None and awake is not None:
+            metrics["sleep_total_minutes"] = asleep + awake
+        elif asleep is not None:
+            metrics["sleep_total_minutes"] = asleep
+
+    return day, metrics

--- a/tests/test_apple_client.py
+++ b/tests/test_apple_client.py
@@ -1,0 +1,107 @@
+import json
+from datetime import date
+from pathlib import Path
+from typing import List, Tuple
+from zipfile import ZipFile
+
+from pete_e.core.apple_client import process_apple_health_export
+
+
+class StubDal:
+    def __init__(self) -> None:
+        self.saved: List[Tuple[date, dict]] = []
+
+    def save_apple_daily(self, day: date, metrics: dict) -> None:  # pragma: no cover - interface hook
+        self.saved.append((day, metrics))
+
+
+def _make_zip(tmp_path: Path, filename: str, payload: object) -> Path:
+    archive = tmp_path / "apple_export.zip"
+    with ZipFile(archive, "w") as zf:
+        zf.writestr(filename, json.dumps(payload))
+    return archive
+
+
+def test_process_apple_health_export_single_day(tmp_path: Path) -> None:
+    payload = {
+        "source": "apple_shortcut",
+        "date": "2025-08-27",
+        "timezone": "Europe/London",
+        "steps": 2948,
+        "hr_min": 47,
+        "hr_max": 120,
+        "hr_avg": 60,
+        "hr_resting": 50,
+        "exercise_minutes": 6,
+        "calories_active": 343,
+        "calories_resting": 1999,
+        "calories_total": 2342,
+        "stand_minutes": 55,
+        "distance_m": 2166,
+        "sleep_minutes": {
+            "asleep": 362,
+            "awake": 7,
+            "core": 218,
+            "deep": 54,
+            "in_bed": 369,
+            "rem": 90,
+        },
+    }
+
+    archive = _make_zip(tmp_path, "health.json", payload)
+    dal = StubDal()
+
+    processed = process_apple_health_export(str(archive), dal=dal)
+
+    assert processed == 1
+    assert len(dal.saved) == 1
+    saved_date, metrics = dal.saved[0]
+    assert saved_date.isoformat() == payload["date"]
+    assert metrics["steps"] == payload["steps"]
+    assert metrics["hr_resting"] == payload["hr_resting"]
+    assert metrics["sleep_total_minutes"] == payload["sleep_minutes"]["in_bed"]
+
+
+def test_process_apple_health_export_nested_payloads(tmp_path: Path) -> None:
+    payload = {
+        "data": [
+            {
+                "summary_date": "2025-08-28T00:00:00Z",
+                "activity": {"steps": "3210", "exercise_minutes": "10"},
+                "calories": {"active": "220", "resting": "1500", "total": "1720"},
+                "heart_rate": {"min": "45", "max": "110", "avg": "70", "resting": "55"},
+                "distance": {"km": "5.5"},
+                "sleep": {"minutes": {"asleep": "360", "awake": "30"}},
+            },
+            {
+                "summary_date": "2025-08-29",
+                "steps": 4000,
+                "exercise_minutes": 12,
+                "calories_active": 300,
+                "calories_resting": 1600,
+                "heart_rate": {"min": 50, "max": 115, "avg": 68, "resting": 52},
+                "sleep_minutes": {"asleep": 390, "awake": 20, "rem": 80, "deep": 70, "core": 240},
+            },
+        ]
+    }
+
+    archive = _make_zip(tmp_path, "nested.json", payload)
+    dal = StubDal()
+
+    processed = process_apple_health_export(str(archive), dal=dal)
+
+    assert processed == 2
+    saved_dates = {d.isoformat(): metrics for d, metrics in dal.saved}
+
+    first_metrics = saved_dates["2025-08-28"]
+    assert first_metrics["steps"] == 3210
+    assert first_metrics["exercise_minutes"] == 10
+    assert first_metrics["calories_active"] == 220
+    assert first_metrics["calories_resting"] == 1500
+    assert first_metrics["distance_m"] == 5500
+    assert first_metrics["sleep_total_minutes"] == 390
+
+    second_metrics = saved_dates["2025-08-29"]
+    assert second_metrics["sleep_total_minutes"] == 410  # asleep + awake fallback
+    assert second_metrics["sleep_rem_minutes"] == 80
+    assert second_metrics["sleep_deep_minutes"] == 70


### PR DESCRIPTION
## Summary
- implement `process_apple_health_export` to read Apple Health export archives, normalise their payloads, and persist them through the DAL
- add helper utilities that support varied JSON layouts, including nested calorie, heart-rate, and sleep data structures
- create tests covering single-day and multi-day payloads to ensure ingestion and normalisation behave as expected

## Testing
- PYTHONPATH=. pytest *(fails: missing optional dependencies `pydantic` and `psycopg` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e42c8794832f97c4b9eab4672c73