### PR TITLE
Keep Postgres pool open across requests

### DIFF
--- a/pete_e/core/apple_service.py
+++ b/pete_e/core/apple_service.py
@@ -4,8 +4,8 @@ FastAPI service to receive Apple Health summaries.
 from fastapi import FastAPI, HTTPException
 from datetime import datetime
 
-# Assuming DAL and close_pool are in this structure
-from pete_e.data_access.postgres_dal import PostgresDal, close_pool
+# Assuming DAL is in this structure
+from pete_e.data_access.postgres_dal import PostgresDal
 from pete_e.infra import log_utils
 
 app = FastAPI()
@@ -38,6 +38,4 @@ def receive_summary(payload: dict):
     except Exception as e:
         log_utils.log_message(f"Failed to process Apple payload: {e}", "ERROR")
         raise HTTPException(status_code=500, detail="Internal server error.")
-    finally:
-        # This block ensures the pool is closed even if an error occurs
-        close_pool()
+


### PR DESCRIPTION
## Summary
- stop closing the Postgres connection pool when handling `/summary` requests so the FastAPI service can reuse connections
- remove the unused `close_pool` import from the Apple service module

## Testing
- pytest *(fails: missing dependencies such as pydantic/psycopg; installing via `pip install -e .[dev]` blocked by proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e6f26178832f843b3b27e9f0860b