### PR TITLE
Sanitize Telegram error logging

### DIFF
--- a/pete_e/infra/telegram_sender.py
+++ b/pete_e/infra/telegram_sender.py
@@ -27,5 +27,16 @@ def send_message(message: str) -> bool:
         log_utils.log_message("Successfully sent message to Telegram.", "INFO")
         return True
     except requests.RequestException as e:
-        log_utils.log_message(f"Failed to send message to Telegram: {e}", "ERROR")
+        error_details = str(e).strip()
+        if not error_details:
+            error_details = e.__class__.__name__
+
+        for sensitive_value in (token, chat_id):
+            if sensitive_value:
+                error_details = error_details.replace(sensitive_value, "[redacted]")
+
+        log_utils.log_message(
+            f"Failed to send message to Telegram: {error_details}",
+            "ERROR",
+        )
         return False


### PR DESCRIPTION
## Summary
- sanitize the Telegram sender's error logging to redact sensitive token/chat identifiers
- provide a fallback to the exception class name when the error message is empty

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pete_e')*

------
https://chatgpt.com/codex/tasks/task_e_68c8e935ac5c832f994d4be2709b6d60