### PR TITLE
Secure Apple summary endpoint with token auth

### DIFF
--- a/pete_e/config.py
+++ b/pete_e/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
     WITHINGS_REFRESH_TOKEN: str
     WGER_API_KEY: str
     WGER_API_URL: str = "https://wger.de/api/v2"
+    APPLE_WEBHOOK_TOKEN: Optional[str] = None
 
     # --- DATABASE (from environment) ---
     POSTGRES_USER: Optional[str] = None

--- a/pete_e/core/apple_service.py
+++ b/pete_e/core/apple_service.py
@@ -1,10 +1,12 @@
-"""
-FastAPI service to receive Apple Health summaries.
-"""
-from fastapi import FastAPI, HTTPException
+"""FastAPI service to receive Apple Health summaries."""
+
+import secrets
 from datetime import datetime
 
+from fastapi import FastAPI, HTTPException, Header, status
+
 # Assuming DAL is in this structure
+from pete_e.config import settings
 from pete_e.data_access.postgres_dal import PostgresDal
 from pete_e.infra import log_utils
 
@@ -15,12 +17,27 @@ def read_root():
     return {"message": "Pete-Eebot Apple Service is running."}
 
 @app.post("/summary")
-def receive_summary(payload: dict):
+def receive_summary(payload: dict, x_apple_webhook_token: str = Header(default=None)):
     """
     Receives a daily summary payload and saves it to the database.
     Payload should be a JSON object with a 'date' key (YYYY-MM-DD)
     and other Apple Health metrics.
     """
+    expected_token = settings.APPLE_WEBHOOK_TOKEN
+    if not expected_token:
+        log_utils.log_message("APPLE_WEBHOOK_TOKEN not configured; rejecting request.", "ERROR")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Apple webhook token not configured.",
+        )
+
+    if not x_apple_webhook_token or not secrets.compare_digest(x_apple_webhook_token, expected_token):
+        log_utils.log_message("Rejected Apple payload due to invalid authentication token.", "WARNING")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication token.",
+        )
+
     log_utils.log_message(f"Received Apple Health payload: {payload.get('date')}", "INFO")
     if not payload or not payload.get("date"):
         raise HTTPException(status_code=400, detail="Payload missing or date field not found.")

--- a/tests/test_apple_service.py
+++ b/tests/test_apple_service.py
@@ -1,0 +1,50 @@
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from pete_e.core import apple_service
+
+
+def _set_token(monkeypatch, token: str | None) -> None:
+    monkeypatch.setattr(apple_service.settings, "APPLE_WEBHOOK_TOKEN", token)
+
+
+def test_receive_summary_rejects_missing_token_config(monkeypatch) -> None:
+    _set_token(monkeypatch, None)
+    client = TestClient(apple_service.app)
+
+    response = client.post("/summary", json={"date": "2024-01-01"})
+
+    assert response.status_code == 500
+
+
+def test_receive_summary_rejects_request_without_token(monkeypatch) -> None:
+    _set_token(monkeypatch, "expected-token")
+    client = TestClient(apple_service.app)
+
+    response = client.post("/summary", json={"date": "2024-01-02"})
+
+    assert response.status_code == 401
+
+
+def test_receive_summary_accepts_valid_token(monkeypatch) -> None:
+    captured = {}
+
+    class DummyDal:
+        def save_apple_daily(self, day: date, metrics: dict) -> None:
+            captured["day"] = day
+            captured["metrics"] = metrics
+
+    monkeypatch.setattr(apple_service, "PostgresDal", lambda: DummyDal())
+    _set_token(monkeypatch, "expected-token")
+    client = TestClient(apple_service.app)
+
+    response = client.post(
+        "/summary",
+        json={"date": "2024-01-03"},
+        headers={"X-Apple-Webhook-Token": "expected-token"},
+    )
+
+    assert response.status_code == 200
+    assert captured["day"].isoformat() == "2024-01-03"
+    assert captured["metrics"]["date"] == "2024-01-03"


### PR DESCRIPTION
## Summary
- require a shared secret token for the Apple Health `/summary` endpoint before processing data
- log and reject requests when the webhook token is missing, invalid, or misconfigured
- add regression tests covering missing token configuration, missing header, and successful authenticated submissions

## Testing
- `PYTHONPATH=. pytest` *(fails: missing dependencies such as pydantic/psycopg in the environment)*
- `pip install -e .[dev]` *(fails: proxy prevents downloading build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e91b99e0832fac6b897e773c4b0b