### PR TITLE
Align narrative builder API with orchestrator

### DIFF
--- a/pete_e/core/narratives.py
+++ b/pete_e/core/narratives.py
@@ -1,11 +1,21 @@
 from .narrative_builder import (
-    build_daily_narrative,
-    build_weekly_narrative,
+    NarrativeBuilder,
     build_cycle_narrative,
+    build_cycle_summary,
+    build_daily_narrative,
+    build_daily_summary,
+    build_weekly_narrative,
+    build_weekly_plan_summary,
+    build_weekly_summary,
 )
 
 __all__ = [
+    "NarrativeBuilder",
     "build_daily_narrative",
     "build_weekly_narrative",
     "build_cycle_narrative",
+    "build_daily_summary",
+    "build_weekly_summary",
+    "build_cycle_summary",
+    "build_weekly_plan_summary",
 ]


### PR DESCRIPTION
## Summary
- add convenience wrappers and a NarrativeBuilder facade so the orchestrator calls the correct APIs
- provide a human-readable weekly plan summary generator for plan data
- re-export the new helpers from the narratives module for consistency

## Testing
- PYTHONPATH=. pytest *(fails: missing optional dependencies such as pydantic/psycopg in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e96975ec832f8d2a762eeddba264