### PR TITLE
Pin dependency versions in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,25 +5,25 @@ description = "Personal health and fitness orchestrator."
 
 # These are the essential packages needed to RUN the application
 dependencies = [
-    "psycopg[binary,pool]",
-    "pydantic",
-    "pydantic-settings",
-    "requests",
-    "fastapi",
-    "uvicorn[standard]",
-    "typer[all]",
-    "Jinja2",
-    "python-dateutil>=2.8.2",
+    "psycopg[binary,pool]==3.1.18",
+    "pydantic==2.6.4",
+    "pydantic-settings==2.2.1",
+    "requests==2.31.0",
+    "fastapi==0.110.0",
+    "uvicorn[standard]==0.27.1",
+    "typer[all]==0.12.1",
+    "Jinja2==3.1.3",
+    "python-dateutil==2.8.2",
 ]
 
 [project.optional-dependencies]
 # These are packages for development, testing, and publishing.
 # Install with: pip install .[dev]
 dev = [
-    "pytest",
-    "rich",
-    "twine",
-    "ruff",
+    "pytest==8.1.1",
+    "rich==13.7.0",
+    "twine==4.0.2",
+    "ruff==0.3.7",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- pin all runtime dependencies in `pyproject.toml` to exact versions for reproducible installs
- lock development extra dependencies to concrete versions to keep tooling consistent

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pete_e' because dependencies are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb5ca1d4832f90e0a59cb98cff53