### PR TITLE
Use tenacity for sync retries

### DIFF
--- a/pete_e/core/sync.py
+++ b/pete_e/core/sync.py
@@ -5,7 +5,16 @@ This script acts as a simple entry point for the synchronization process,
 which is orchestrated by the Orchestrator class. It's intended to be
 run from the main CLI.
 """
-import time
+from typing import Iterable, Optional
+
+from tenacity import (
+    RetryCallState,
+    RetryError,
+    Retrying,
+    stop_after_attempt,
+    wait_exponential,
+    wait_random,
+)
 
 from pete_e.core.orchestrator import Orchestrator
 from pete_e.infra import log_utils
@@ -13,28 +22,74 @@ from pete_e.infra import log_utils
 DEFAULT_RETRIES = 3
 DEFAULT_RETRY_DELAY_SECS = 60
 
+
+class SyncAttemptFailedError(RuntimeError):
+    """Represents a failed sync attempt that should be retried."""
+
+    def __init__(self, failed_sources: Optional[Iterable[str]] = None) -> None:
+        super().__init__("Sync attempt failed.")
+        self.failed_sources = list(failed_sources or [])
+
+
 def run_sync_with_retries(
     days: int,
     retries: int = DEFAULT_RETRIES,
     delay: int = DEFAULT_RETRY_DELAY_SECS,
 ) -> bool:
-    """
-    Run the sync via the Orchestrator with a simple retry mechanism.
-    """
+    """Run the sync via the Orchestrator with a configurable retry strategy."""
+
     orchestrator = Orchestrator()
-    for attempt in range(1, max(1, retries) + 1):
+    max_attempts = max(1, retries)
+    base_delay = max(1, delay)
+
+    def _sync_once() -> bool:
         success, failed_sources = orchestrator.run_daily_sync(days=days)
         if success:
             return True
+        raise SyncAttemptFailedError(failed_sources)
 
-        if attempt < retries:
-            log_utils.log_message(
-                f"Sync attempt {attempt}/{retries} had failures in: {failed_sources}. "
-                f"Retrying in {delay}s...", "WARN"
-            )
-            time.sleep(max(1, delay))
+    def _before_sleep(retry_state: RetryCallState) -> None:
+        wait_time = getattr(retry_state.next_action, "sleep", base_delay)
+        wait_time_str = f"{wait_time:.2f}".rstrip("0").rstrip(".") or "0"
+        exception = retry_state.outcome.exception()
 
-    log_utils.log_message(
-        f"All {retries} sync attempts finished with failures.", "ERROR"
+        if isinstance(exception, SyncAttemptFailedError):
+            reason = f"failures in: {exception.failed_sources}"
+        else:
+            reason = f"exception: {exception}"
+
+        log_utils.log_message(
+            (
+                f"Sync attempt {retry_state.attempt_number}/{max_attempts} "
+                f"had {reason}. Retrying in {wait_time_str}s..."
+            ),
+            "WARN",
+        )
+
+    retryer = Retrying(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential(
+            multiplier=base_delay,
+            min=base_delay,
+            max=base_delay * 8,
+        )
+        + wait_random(0, base_delay),
+        before_sleep=_before_sleep,
+        reraise=True,
     )
-    return False
+
+    try:
+        retryer(_sync_once)
+        return True
+    except RetryError as exc:
+        last_exception = exc.last_attempt.exception()
+        message = f"All {max_attempts} sync attempts finished with failures."
+
+        if isinstance(last_exception, SyncAttemptFailedError):
+            if last_exception.failed_sources:
+                message += f" Failures in: {last_exception.failed_sources}."
+        elif last_exception is not None:
+            message += f" Last exception: {last_exception}."
+
+        log_utils.log_message(message, "ERROR")
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "typer[all]",
     "Jinja2",
     "python-dateutil>=2.8.2",
+    "tenacity",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- replace the manual sleep-based retry loop in `run_sync_with_retries` with a tenacity-powered strategy that supports exponential backoff and jitter
- add the tenacity package to the project dependencies so the new retry helper is available at runtime

## Testing
- `pip install -e .[dev]` *(fails: cannot reach package index through proxy, so build dependencies could not be installed)*
- `pytest` *(fails: environment lacks installed project dependencies such as `fastapi` and `pete_e`)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eb34e01c832fadc5b660275f1cd9