### PR TITLE
Add filtering to lift log retrieval

### DIFF
--- a/pete_e/core/lift_log.py
+++ b/pete_e/core/lift_log.py
@@ -34,7 +34,7 @@ def get_history_for_exercise(
     Retrieves history for an exercise using the provided DAL.
     Includes set_number for clarity.
     """
-    log = dal.load_lift_log()
+    log = dal.load_lift_log(exercise_ids=[exercise_id])
     entries = log.get(str(exercise_id), [])
 
     # Ensure set_number is included if not already

--- a/pete_e/core/progression.py
+++ b/pete_e/core/progression.py
@@ -19,7 +19,24 @@ def apply_progression(
     """Adjust weights based on lift log and recovery metrics."""
 
     if lift_history is None:
-        lift_history = dal.load_lift_log()
+        requested_ids: set[int] = set()
+        for day in week.get("days", []):
+            for session in day.get("sessions", []):
+                if session.get("type") != "weights":
+                    continue
+                for ex in session.get("exercises", []):
+                    ex_id = ex.get("id")
+                    if ex_id is None:
+                        continue
+                    try:
+                        requested_ids.add(int(ex_id))
+                    except (TypeError, ValueError):
+                        continue
+
+        if requested_ids:
+            lift_history = dal.load_lift_log(exercise_ids=list(requested_ids))
+        else:
+            lift_history = {}
 
     recent_metrics = dal.get_historical_metrics(7)
     baseline_metrics = dal.get_historical_metrics(settings.BASELINE_DAYS)

--- a/pete_e/data_access/dal.py
+++ b/pete_e/data_access/dal.py
@@ -27,6 +27,16 @@ class DataAccessLayer(ABC):
         pass
 
     @abstractmethod
+    def load_lift_log(
+        self,
+        exercise_ids: Optional[List[int]] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+    ) -> Dict[str, Any]:
+        """Return lift log entries grouped by exercise id."""
+        pass
+
+    @abstractmethod
     def save_body_age_daily(self, day: date, metrics: Dict[str, Any]) -> None:
         pass
 

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -13,7 +13,15 @@ class DummyDal(DataAccessLayer):
         self._metrics_baseline = metrics_baseline
 
     # Lift log operations
-    def load_lift_log(self) -> Dict[str, Any]:
+    def load_lift_log(
+        self,
+        exercise_ids: List[int] | None = None,
+        start_date: datetime.date | None = None,
+        end_date: datetime.date | None = None,
+    ) -> Dict[str, Any]:
+        if exercise_ids:
+            keys = {str(e) for e in exercise_ids}
+            return {k: v for k, v in self._lift_history.items() if k in keys}
         return self._lift_history
 
     def save_lift_log(self, log: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- extend the DataAccessLayer lift log contract to accept optional exercise and date filters
- update the Postgres DAL to push filtering into the SQL query and iterate rows lazily
- adjust progression and lift log helpers (and their tests) to request only the exercises they need

## Testing
- pytest *(fails: environment missing pete_e package import path and FastAPI dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c930862f0c832f89e7473514ec4405