### PR TITLE
Integrate Dropbox Apple ingest into daily sync

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -111,6 +111,11 @@ def stub_clients(monkeypatch):
     monkeypatch.setattr(orchestrator_module, "WithingsClient", DummyWithingsClient)
     monkeypatch.setattr(orchestrator_module, "WgerClient", DummyWgerClient)
     monkeypatch.setattr(Orchestrator, "_recalculate_body_age", lambda self, target_day: None)
+    monkeypatch.setattr(
+        orchestrator_module,
+        "run_apple_health_ingest",
+        lambda: types.SimpleNamespace(sources=[], workouts=0, daily_points=0),
+    )
 
 
 def test_run_daily_sync_handles_absent_apple_data():


### PR DESCRIPTION
## Summary
- run the Dropbox-based Apple Health ingest at the start of the orchestrator daily sync and log the import summary
- treat Dropbox ingest failures as a sync source error
- update orchestrator tests to stub the Dropbox ingest helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceeb20be48832fb62601f94dfd032b