### PR TITLE
Refactor progression to read flat Apple metrics

### DIFF
--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -108,7 +108,7 @@ class DummyDal(DataAccessLayer):
 
 def make_metrics(rhr: float, sleep: float, days: int) -> List[Dict[str, Any]]:
     return [
-        {"apple": {"heart_rate": {"resting": rhr}, "sleep": {"asleep": sleep}}}
+        {"hr_resting": rhr, "sleep_asleep_minutes": sleep}
         for _ in range(days)
     ]
 


### PR DESCRIPTION
## Summary
- update the progression recovery checks to use the flat daily summary keys for resting heart rate and sleep
- document where future Apple metrics like HRV and sleep stages could be applied
- align the progression unit test fixtures with the new metric structure

## Testing
- `PYTHONPATH=. pytest tests/test_progression.py`


------
https://chatgpt.com/codex/tasks/task_e_68cef18a47d8832f8016194a74aabc30