### PR TITLE
Fix messaging summary flow and surface plan adjustments

### DIFF
--- a/pete_e/application/orchestrator.py
+++ b/pete_e/application/orchestrator.py
@@ -54,7 +54,7 @@ class Orchestrator:
             except Exception as e:
                 log_utils.log_message(f"Failed to send Apple Health nudge: {e}", "WARN")
 
-                return self.narrative_builder.build_daily_summary(summary_data)
+        return self.narrative_builder.build_daily_summary(summary_data)
 
 
 

--- a/pete_e/application/wger_sender.py
+++ b/pete_e/application/wger_sender.py
@@ -37,7 +37,7 @@ def send_plan_week_to_wger(
     Validate plan → adjust DB → wrangle into Wger JSON → POST to Wger.
     """
     # 1. Validate + adjust
-    adjustments = validate_and_adjust_plan(dal, plan_id, week_number, current_start_date)
+    adjustments = validate_and_adjust_plan(dal, current_start_date)
 
     # 2. Fetch updated plan week
     plan = dal.get_plan(plan_id)
@@ -53,9 +53,10 @@ def send_plan_week_to_wger(
     # 4. Send to Wger
     try:
         response = client.post_plan(payload)
+        adjustment_text = ", ".join(adjustments) if adjustments else "none"
         log_utils.log_message(
             f"[send_wger] Sent plan {plan_id} week {week_number} to Wger. "
-            f"Adjustments: {adjustments}. Response: {response}",
+            f"Adjustments: {adjustment_text}. Response: {response}",
             "INFO"
         )
         return True


### PR DESCRIPTION
## Summary
- ensure the orchestrator always returns a daily summary string after optional Apple Health nudges
- expose recovery validation adjustments (severity, multipliers, reasons) for weekly plan deployments
- update the Wger sender to use the simplified validation signature and log readable adjustment details

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef469982c832fbcdcb0271d0b07ad