### PR TITLE
Refresh docs for Dropbox ingest

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,13 @@ WITHINGS_CLIENT_SECRET=<your-withings-client-secret-here>
 WITHINGS_REDIRECT_URI=<your-withings-redirect-uri-here>
 WITHINGS_REFRESH_TOKEN=<your-withings-refresh-token-here>
 
+# Dropbox
+DROPBOX_APP_KEY=<your-dropbox-app-key-here>
+DROPBOX_APP_SECRET=<your-dropbox-app-secret-here>
+DROPBOX_REFRESH_TOKEN=<your-dropbox-refresh-token-here>
+DROPBOX_HEALTH_METRICS_DIR=<dropbox-path-to-health-metrics>
+DROPBOX_WORKOUTS_DIR=<dropbox-path-to-workouts>
+
 # WGER
 WGER_API_KEY=<your-wger-api-key-here>
 
@@ -30,3 +37,4 @@ DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}
 
 # GitHub
 GH_SECRETS_TOKEN=<your-github-secrets-token-here>
+

--- a/README.md
+++ b/README.md
@@ -1,72 +1,85 @@
 # Pete Eebot
 
-This repository contains a set of tools and workflows to consolidate personal fitness data from various sources, including Withings, Apple Health, and wger workout manager. It uses GitHub Actions to automate data fetching, processing, and storage, creating a personal fitness data warehouse.
+Pete-Eebot is a personal health and fitness orchestrator. The application ingests data from connected services, persists it in Postgres, analyses daily readiness, and prepares weekly training plans and summaries that can be reviewed or pushed to Telegram.
 
------
+---
 
 ## Key Features
 
-  * **Automated Data Sync:** Daily synchronization of health and fitness data from multiple platforms.
-  * **Data Consolidation:** Centralizes weight, body composition, activity, sleep, and workout data into CSV and JSON formats.
-  * **"Body Age" Calculation:** A daily updated "body age" is calculated based on consolidated metrics.
-  * **Personalized Goal Tracking:** Accommodates individual fitness goals, nutrition plans, and progress reviews.
+* **Unified data sync:** A single CLI command keeps Withings, Apple Health, and wger data aligned in the database.
+* **Dropbox-based Apple ingest:** Health Auto Export shortcuts drop JSON/ZIP files into Dropbox; the ingest job downloads and loads only the new files each run.
+* **Body age insights:** Daily body age scores highlight long-term trends across movement, recovery, and composition data.
+* **Training plan automation:** Plan blocks are generated directly from the data warehouse and can be shared via the messenger commands.
 
------
+---
 
 ## Data Sources and Integrations
 
-  * **Withings:** Syncs weight, body fat, muscle mass, and water percentage data. This is achieved through OAuth integration and a daily GitHub Actions workflow.
-  * **Apple Health:** Captures detailed daily activity metrics via an iOS Shortcut, including steps, heart rate, active and resting calories, and sleep data.
-  * **wger:** Imports workout logs, including exercise names, categories, reps, and weight.
+* **Withings:** OAuth credentials are stored locally. The sync pipeline refreshes tokens as needed and pulls weight and body composition summaries for the requested backfill window.
+* **Apple Health:** An iOS Shortcut exports Health Auto Export files to Dropbox. The Dropbox client collects any new metric or workout files, parses them, and writes them into the analytics schema.
+* **wger:** Strength training logs are fetched through the wger API and blended with health metrics for the weekly plan narrative.
 
------
+---
 
-## Repository Structure
+## Repository Layout
 
 ```
 .
-├── .github/workflows/       # GitHub Actions workflows for data syncing
-├── docs/                      # Raw and processed data from various sources
-│   ├── analytics/           # Body age calculations and history
-│   ├── apple/               # Apple Health data
-│   ├── days/                # Consolidated daily data
-│   └── withings/            # Withings data
-├── integrations/            # Scripts and configuration for data integrations
-│   └── withings/
-├── knowledge/               # Core fitness data and plans in CSV and Markdown
-└── summaries/               # Daily data summaries
+├── pete_e/                 # Python package containing the active application code
+│   ├── application/        # Orchestration flows (sync, Dropbox ingest, plan generation)
+│   ├── cli/                # Typer-powered command line interface
+│   ├── config/             # Environment-driven settings
+│   ├── domain/             # Business rules (progression, plans, narratives, analytics)
+│   ├── infrastructure/     # DAL, API clients, and integrations
+│   └── resources/          # Static assets used by the application
+├── scripts/                # One-off helpers for maintenance and reviews
+├── tests/                  # Pytest suite for ingestion, orchestration, and validation logic
+├── docs/                   # Design notes and analytical documentation
+├── deprecated/             # Legacy FastAPI/Tailscale implementation retained for reference
+├── docker-compose.yml      # Local Postgres bootstrap for development
+└── init-db/                # SQL migrations used by the active schema
 ```
 
------
+---
 
-## How It Works
+## Configuration
 
-This system is orchestrated through a series of GitHub Actions workflows:
+1. Copy `.env.sample` to `.env` and populate the secrets.
+2. Provide Dropbox credentials (`DROPBOX_APP_KEY`, `DROPBOX_APP_SECRET`, `DROPBOX_REFRESH_TOKEN`) and the folder paths produced by Health Auto Export (`DROPBOX_HEALTH_METRICS_DIR`, `DROPBOX_WORKOUTS_DIR`).
+3. Fill in the remaining Withings, Telegram, wger, and Postgres values. The configuration module will construct `DATABASE_URL` automatically on load.
+4. Run `pip install .[dev]` (or use your preferred virtual environment manager) to install the package and its development dependencies.
 
-1.  **`withings_sync.yml`:** Runs daily to fetch weight and body composition data from the Withings API. It refreshes the OAuth token, updates the `weight_log.csv`, and stores the raw data.
-2.  **`apple_sync.yml`:** Triggered by a webhook from an iOS Shortcut, this workflow processes and commits data from Apple Health. It updates `activity_log.csv`, `cardio_log.csv`, and `recovery_log.csv`.
-3.  **`wger_sync.yml`:** A scheduled workflow that pulls workout data from the wger API and updates `workout_log.csv`.
-4.  **`body_age.yml`:** After the data syncs, this workflow calculates a "body age" based on a composite score of recent fitness and health data. The results are logged in `body_age_log.csv`.
+The settings layer exposes derived paths such as `logs/pete_history.log`. When running locally the log directory is created automatically.
 
-The `index.html` file serves as a convenient redirect handler for the Withings OAuth process, simplifying the initial setup.
+---
 
------
+## CLI Usage
 
-## Knowledge Base
+The project ships a Typer application under the `pete-e` entry point. Common commands:
 
-The `/knowledge` directory is the heart of this repository, containing structured data and plans for a personalized fitness journey.
+* `pete-e refresh-withings` – force-refreshes the Withings OAuth tokens and prints the truncated values.
+* `pete-e ingest-apple` – downloads new Health Auto Export files from Dropbox and persists the parsed metrics.
+* `pete-e sync --days 7` – runs the multi-source sync (Dropbox, Withings, wger) with retry handling.
+* `pete-e withings-sync` – executes the Withings-only branch of the pipeline.
+* `pete-e plan --weeks 4` – generates and deploys the next training plan block.
+* `pete-e message --summary` / `--plan` – renders summaries and optionally pushes them to Telegram with `--send`.
 
-### Data Logs
+Logs for each command are appended to `logs/pete_history.log`, making it easy to audit Dropbox downloads and downstream calculations.
 
-  * **`activity_log.csv`:** Daily activity metrics.
-  * **`body_age_log.csv`:** A log of the calculated "body age" over time.
-  * **`cardio_log.csv`:** Heart rate data.
-  * **`recovery_log.csv`:** Sleep and recovery metrics.
-  * **`weight_log.csv`:** Daily weight and body composition.
+---
 
-### Fitness and Nutrition Plans
+## Testing
 
-  * **`goals.md`:** Outlines fitness goals, including target weight and milestones.
-  * **`nutrition_plan.md`:** Details the daily nutrition strategy, including fixed meals and macronutrient targets.
-  * **`plan_weekly_template.md`:** A template for a weekly training plan.
-  * **`gym_resources.md`:** Information on gym classes and a strength training progression plan.
+Run the automated test suite with:
+
+```
+pytest
+```
+
+The tests provide in-memory doubles for the DAL and Dropbox client, ensuring the new module structure and ingestion format remain stable.
+
+---
+
+## Legacy Code
+
+The `deprecated/` directory contains the retired FastAPI webhook and the original Tailscale-based Apple ingestion flow. It is kept for historical reference only; new development should rely on the active package in `pete_e/`.

--- a/deprecated/README.md
+++ b/deprecated/README.md
@@ -1,0 +1,9 @@
+# Deprecated Components
+
+This directory contains legacy artifacts that are no longer part of the active Pete-Eebot package. The files are retained for historical reference only.
+
+* `pete_e/` – the previous FastAPI webhook implementation and the Tailscale-based Apple Health ingestion path.
+* SQL migration drafts that have since been superseded by the scripts in `init-db/`.
+
+Do not modify or reuse this code in new development unless you are intentionally reviving the legacy stack.
+


### PR DESCRIPTION
## Summary
- update the root README to describe the Dropbox-based ingestion flow and active CLI commands
- add the Dropbox configuration entries to `.env.sample`
- document the legacy code that now lives under `deprecated/`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef5ba4334832f861c746c31106a80