### PR TITLE
Add auth status helper and document token setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,27 @@ The remainder of this README assumes you chose the virtual environment path.
 4. Optional reliability tuning: set `APPLE_MAX_STALE_DAYS` (default `3`) to adjust the Dropbox stagnation alert window, and toggle `WITHINGS_ALERT_REAUTH` (default `true`) if you want to silence token re-authorisation nudges.
 5. Install the pinned dependencies with `python -m pip install -r requirements.txt`, then register the CLI with `python -m pip install --no-deps -e .`. Both commands should run inside your activated virtual environment.
 
+### First-time OAuth setup
+
+Run these steps once when you provision a new deployment or rotate credentials:
+
+**Withings**
+
+1. Generate an authorisation URL with `pete-e withings-auth-url`.
+2. Open the printed link in a browser, approve the `Pete Eebot` app, and copy the `code=...` value from the redirect URL.
+3. Exchange the code for tokens: `pete-e withings-exchange-code <code>`.
+4. Confirm persistence by running `pete-e refresh-withings`, which refreshes the access token and saves the results to `.withings_tokens.json`.
+
+**Dropbox**
+
+1. Visit the [Dropbox App Console](https://www.dropbox.com/developers/apps) and create a **Scoped App** with at least `files.metadata.read` and `files.content.read` permissions.
+2. Generate the app key and secret, then use the "Generate" button in the console to obtain a long-lived refresh token for the same app.
+3. Add `DROPBOX_APP_KEY`, `DROPBOX_APP_SECRET`, and `DROPBOX_REFRESH_TOKEN` to your `.env` file alongside the export directory paths.
+
+**Sanity check**
+
+`python -m scripts.check_auth` prints a short summary showing whether Withings and Dropbox tokens are in place or highlights the next steps to finish setup. The script works offline, so you can run it before enabling network access on a new host.
+
 The settings layer exposes derived paths such as `logs/pete_history.log`. When running locally the log directory is created automatically.
 
 ---

--- a/scripts/check_auth.py
+++ b/scripts/check_auth.py
@@ -1,0 +1,216 @@
+"""Utility for checking Pete Eebot auth prerequisites.
+
+This module inspects the locally stored Withings token file and the
+environment-backed Dropbox credentials to confirm that the inputs needed for
+scheduled syncs are present. No network calls are performed – the script only
+looks at files and configuration values that already exist on disk.
+
+Run via ``python -m scripts.check_auth`` to print a small status report.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+
+TOKEN_FILE_NAME = ".withings_tokens.json"
+
+
+@dataclass(frozen=True)
+class AuthStatus:
+    """Represents the outcome of a credential check."""
+
+    name: str
+    state: str
+    message: str
+
+    def format_line(self) -> str:
+        """Render the status in a CLI-friendly format."""
+
+        labels = {
+            "ok": "OK",
+            "warning": "ATTENTION",
+            "action_required": "ACTION REQUIRED",
+        }
+        label = labels.get(self.state, self.state.upper())
+        return f"{self.name}: {label} – {self.message}"
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    """Load a minimal .env style file into a dictionary."""
+
+    if not path.exists():
+        return {}
+
+    env: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+
+        key = key.strip()
+        value = value.strip()
+
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+
+        env[key] = value
+    return env
+
+
+def determine_withings_status(env: Mapping[str, str], token_path: Path) -> AuthStatus:
+    """Return the current Withings authorisation status."""
+
+    name = "Withings"
+
+    if token_path.exists():
+        try:
+            token_data = json.loads(token_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return AuthStatus(
+                name=name,
+                state="action_required",
+                message=(
+                    f"{TOKEN_FILE_NAME} exists but could not be parsed. Delete the file and "
+                    "re-authorise via `pete-e withings-auth-url` followed by "
+                    "`pete-e withings-exchange-code <code>` to capture fresh tokens."
+                ),
+            )
+
+        refresh_token = str(token_data.get("refresh_token") or "").strip()
+        if refresh_token:
+            updated = datetime.fromtimestamp(
+                token_path.stat().st_mtime, tz=timezone.utc
+            ).strftime("%Y-%m-%d %H:%M UTC")
+            return AuthStatus(
+                name=name,
+                state="ok",
+                message=(
+                    f"Refresh token stored in {TOKEN_FILE_NAME} (updated {updated}). "
+                    "Run `pete-e refresh-withings` if you want to confirm the stored tokens."
+                ),
+            )
+
+        return AuthStatus(
+            name=name,
+            state="action_required",
+            message=(
+                f"{TOKEN_FILE_NAME} is present but missing a refresh_token. "
+                "Re-run `pete-e withings-auth-url` and `pete-e withings-exchange-code <code>` "
+                "to capture a complete token set."
+            ),
+        )
+
+    if env.get("WITHINGS_REFRESH_TOKEN"):
+        return AuthStatus(
+            name=name,
+            state="warning",
+            message=(
+                "Refresh token only lives in .env. Persist it by running "
+                "`pete-e refresh-withings` so future syncs can load "
+                f"{TOKEN_FILE_NAME} without manual edits."
+            ),
+        )
+
+    missing_fields = [
+        key
+        for key in ("WITHINGS_CLIENT_ID", "WITHINGS_CLIENT_SECRET", "WITHINGS_REDIRECT_URI")
+        if not env.get(key)
+    ]
+    if missing_fields:
+        field_list = ", ".join(missing_fields)
+        return AuthStatus(
+            name=name,
+            state="action_required",
+            message=(
+                "Missing Withings developer settings in .env: "
+                f"{field_list}. Create a Withings developer application and update the file before authorising."
+            ),
+        )
+
+    return AuthStatus(
+        name=name,
+        state="action_required",
+        message=(
+            "No refresh token detected. Run `pete-e withings-auth-url`, approve the app, "
+            "then call `pete-e withings-exchange-code <code>` to save the tokens."
+        ),
+    )
+
+
+def determine_dropbox_status(env: Mapping[str, str]) -> AuthStatus:
+    """Return the Dropbox credential status."""
+
+    name = "Dropbox"
+    required_keys = ["DROPBOX_APP_KEY", "DROPBOX_APP_SECRET", "DROPBOX_REFRESH_TOKEN"]
+    missing = [key for key in required_keys if not env.get(key)]
+
+    if not missing:
+        return AuthStatus(
+            name=name,
+            state="ok",
+            message=(
+                "App key, secret, and refresh token are present. Tokens are long-lived, "
+                "but re-run the Dropbox console flow if you ever rotate the app secret."
+            ),
+        )
+
+    if missing == ["DROPBOX_REFRESH_TOKEN"]:
+        return AuthStatus(
+            name=name,
+            state="action_required",
+            message=(
+                "App key and secret found, but no DROPBOX_REFRESH_TOKEN. Visit the Dropbox App Console, "
+                "generate a scoped refresh token for your Health Auto Export app, and add it to .env."
+            ),
+        )
+
+    missing_list = ", ".join(missing)
+    return AuthStatus(
+        name=name,
+        state="action_required",
+        message=(
+            "Missing Dropbox OAuth values in .env: "
+            f"{missing_list}. Create a Dropbox scoped app with files.read access, generate the key, secret, "
+            "and refresh token, then update .env before running syncs."
+        ),
+    )
+
+
+def main() -> int:
+    """Entry point for the script."""
+
+    project_root = Path.cwd()
+    env_path = project_root / ".env"
+    env = load_env_file(env_path)
+    # Environment variables win over file-based values so ad-hoc overrides work.
+    env.update({key: value for key, value in os.environ.items()})
+
+    token_path = project_root / TOKEN_FILE_NAME
+
+    statuses = [
+        determine_withings_status(env, token_path),
+        determine_dropbox_status(env),
+    ]
+
+    for status in statuses:
+        print(status.format_line())
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via tests on the helpers
+    raise SystemExit(main())
+

--- a/tests/test_check_auth.py
+++ b/tests/test_check_auth.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+from scripts.check_auth import (
+    AuthStatus,
+    determine_dropbox_status,
+    determine_withings_status,
+    load_env_file,
+)
+
+
+def test_withings_status_ok_when_token_file_present(tmp_path):
+    token_file = tmp_path / ".withings_tokens.json"
+    token_file.write_text(json.dumps({"refresh_token": "abc", "access_token": "def"}))
+    updated_at = datetime(2024, 5, 1, 8, 30, tzinfo=timezone.utc)
+    os.utime(token_file, (updated_at.timestamp(), updated_at.timestamp()))
+
+    status = determine_withings_status({}, token_file)
+
+    assert isinstance(status, AuthStatus)
+    assert status.state == "ok"
+    assert "Refresh token stored" in status.message
+    assert "2024-05-01 08:30 UTC" in status.message
+
+
+def test_withings_status_warns_when_only_env_refresh_token(tmp_path):
+    token_file = tmp_path / ".withings_tokens.json"
+
+    status = determine_withings_status({"WITHINGS_REFRESH_TOKEN": "abc"}, token_file)
+
+    assert status.state == "warning"
+    assert "refresh-withings" in status.message
+
+
+def test_withings_status_requires_setup_when_app_config_present(tmp_path):
+    token_file = tmp_path / ".withings_tokens.json"
+
+    env = {
+        "WITHINGS_CLIENT_ID": "abc",
+        "WITHINGS_CLIENT_SECRET": "def",
+        "WITHINGS_REDIRECT_URI": "https://example.com/redirect",
+    }
+
+    status = determine_withings_status(env, token_file)
+
+    assert status.state == "action_required"
+    assert "withings-auth-url" in status.message
+
+
+def test_withings_status_flags_missing_app_settings(tmp_path):
+    token_file = tmp_path / ".withings_tokens.json"
+
+    env = {"WITHINGS_CLIENT_ID": "abc"}
+
+    status = determine_withings_status(env, token_file)
+
+    assert status.state == "action_required"
+    assert "WITHINGS_CLIENT_SECRET" in status.message
+    assert "WITHINGS_REDIRECT_URI" in status.message
+
+
+def test_dropbox_status_ok_when_all_present():
+    env = {
+        "DROPBOX_APP_KEY": "key",
+        "DROPBOX_APP_SECRET": "secret",
+        "DROPBOX_REFRESH_TOKEN": "token",
+    }
+
+    status = determine_dropbox_status(env)
+
+    assert status.state == "ok"
+    assert "App key, secret, and refresh token" in status.message
+
+
+def test_dropbox_status_prompts_for_refresh_token_only():
+    env = {"DROPBOX_APP_KEY": "key", "DROPBOX_APP_SECRET": "secret"}
+
+    status = determine_dropbox_status(env)
+
+    assert status.state == "action_required"
+    assert "DROPBOX_REFRESH_TOKEN" in status.message
+
+
+def test_dropbox_status_prompts_for_multiple_missing():
+    env = {}
+
+    status = determine_dropbox_status(env)
+
+    assert status.state == "action_required"
+    assert "DROPBOX_APP_KEY" in status.message
+    assert "DROPBOX_APP_SECRET" in status.message
+
+
+def test_env_loader_handles_export_and_quotes(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        """
+        # comment line
+        export DROPBOX_APP_KEY="abc123"
+        DROPBOX_REFRESH_TOKEN='xyz'
+        INVALID_LINE
+        
+        WITHINGS_CLIENT_ID = something
+        """
+    )
+
+    result = load_env_file(env_file)
+
+    assert result["DROPBOX_APP_KEY"] == "abc123"
+    assert result["DROPBOX_REFRESH_TOKEN"] == "xyz"
+    assert result["WITHINGS_CLIENT_ID"] == "something"
+    assert "INVALID_LINE" not in result
+


### PR DESCRIPTION
## Summary
- document first-time Withings and Dropbox OAuth steps and the new check script in the README
- add an offline `scripts.check_auth` helper that reports token presence and guidance
- cover the helper with unit tests exercising Withings and Dropbox status logic and the env loader

## Testing
- `pytest tests/test_check_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0fd413448832fb53188ec5cbe9439