### PR TITLE
Ensure alerts fall back when Telegram unavailable

### DIFF
--- a/tests/test_failure_modes.py
+++ b/tests/test_failure_modes.py
@@ -154,7 +154,7 @@ def test_run_daily_sync_marks_partial_wger_failure(monkeypatch):
     dal = RecordingDal()
     orch = Orchestrator(dal=dal)
 
-    success, failures, statuses = orch.run_daily_sync(days=1)
+    success, failures, statuses, undelivered = orch.run_daily_sync(days=1)
 
     assert not success
     assert failures == ["Wger"]
@@ -162,6 +162,7 @@ def test_run_daily_sync_marks_partial_wger_failure(monkeypatch):
     assert statuses["Withings"] == "ok"
     assert statuses["AppleDropbox"] == "ok"
     assert statuses["BodyAge"] == "ok"
+    assert undelivered == []
 
     target_day = date.today() - timedelta(days=1)
     assert dal.withings_calls == [(target_day, 82.5, 19.2, 41.7, 55.5)]

--- a/tests/test_ingestion_resilience.py
+++ b/tests/test_ingestion_resilience.py
@@ -193,6 +193,7 @@ def test_sync_result_summary_includes_withings_note():
         failed_sources=["Withings"],
         source_statuses={"AppleDropbox": "ok", "Withings": "failed"},
         label="daily",
+        undelivered_alerts=[],
     )
 
     summary = result.summary_line(days=1)
@@ -209,6 +210,7 @@ def test_sync_result_summary_handles_multi_day_window():
         failed_sources=["Withings"],
         source_statuses={"Withings": "failed"},
         label="daily",
+        undelivered_alerts=[],
     )
 
     summary = result.summary_line(days=3)

--- a/tests/test_sync_summary_log.py
+++ b/tests/test_sync_summary_log.py
@@ -7,7 +7,7 @@ from pete_e.application import sync
 
 
 class _StubOrchestrator:
-    def __init__(self, responses: Iterable[Tuple[bool, List[str], dict]]):
+    def __init__(self, responses: Iterable[Tuple[bool, List[str], dict, List[str]]]):
         self._responses = iter(responses)
 
     def run_daily_sync(self, days: int):  # pragma: no cover - simple stub
@@ -48,6 +48,7 @@ def test_run_sync_logs_single_summary_line_success(tmp_path, monkeypatch):
                         "Wger": "ok",
                         "BodyAge": "ok",
                     },
+                    [],
                 )
             ]
         ),
@@ -68,6 +69,7 @@ def test_run_sync_logs_single_summary_line_success(tmp_path, monkeypatch):
     assert len(summary_lines) == 1
     assert result.success is True
     assert result.failed_sources == []
+    assert result.undelivered_alerts == []
 
     logging_setup.reset_logging()
     for handler in list(logger.handlers):
@@ -92,6 +94,7 @@ def test_run_sync_logs_failure_summary_once(tmp_path, monkeypatch):
                         "Wger": "ok",
                         "BodyAge": "ok",
                     },
+                    [],
                 )
             ]
         ),
@@ -110,6 +113,7 @@ def test_run_sync_logs_failure_summary_once(tmp_path, monkeypatch):
     assert len(summary_lines) == 1
     assert result.success is False
     assert result.failed_sources == ["Withings"]
+    assert result.undelivered_alerts == []
 
     logging_setup.reset_logging()
     for handler in list(logger.handlers):

--- a/tests/test_telegram_alerts.py
+++ b/tests/test_telegram_alerts.py
@@ -70,12 +70,13 @@ def test_total_sync_failure_triggers_single_alert(monkeypatch, alert_spy):
     dal = RecordingDal()
     orch = Orchestrator(dal=dal)
 
-    success, failures, statuses = orch.run_daily_sync(days=2)
+    success, failures, statuses, undelivered = orch.run_daily_sync(days=2)
 
     assert not success
     assert failures == ['AppleDropbox', 'BodyAge', 'Wger', 'Withings']
     assert all(state == 'failed' for state in statuses.values())
     assert len(alert_spy) == 1
+    assert undelivered == []
 
     message = alert_spy[0]
     assert isinstance(message, str)


### PR DESCRIPTION
## Summary
- surface undelivered alert messages when Telegram sending fails and log the fallback path
- propagate pending alerts through `DailyAutomationResult`/`SyncResult` so higher-level flows expose them
- update the test suite to expect the new return signature and to validate the fallback behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d11c13d070832f8bf132d838df5109