### PR TITLE
Restrict Withings token file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Run these steps once when you provision a new deployment or rotate credentials:
 2. Open the printed link in a browser, approve the `Pete Eebot` app, and copy the `code=...` value from the redirect URL.
 3. Exchange the code for tokens: `pete-e withings-exchange-code <code>`.
 4. Confirm persistence by running `pete-e refresh-withings`, which refreshes the access token and saves the results to `.withings_tokens.json`.
+   The helper locks the file down to owner-only permissions (`chmod 600`) so the stored tokens stay private.
 
 **Dropbox**
 

--- a/pete_e/infrastructure/withings_client.py
+++ b/pete_e/infrastructure/withings_client.py
@@ -6,6 +6,7 @@ Now persists tokens in .withings_tokens.json so you donâ€™t have to update 
 """
 
 import json
+import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -88,6 +89,11 @@ class WithingsClient:
         """Persist tokens to disk."""
         with open(self.TOKEN_FILE, "w") as f:
             json.dump(tokens, f, indent=2)
+        # Restrict the token file to the owner so refresh credentials are not exposed.
+        try:
+            os.chmod(self.TOKEN_FILE, 0o600)
+        except OSError as exc:
+            log_message(f"Could not set permissions on {self.TOKEN_FILE}: {exc}", "WARN")
         log_message("Saved Withings tokens to file.", "INFO")
 
     def get_token_state(self) -> WithingsTokenState:

--- a/pete_e/infrastructure/withings_oauth_helper.py
+++ b/pete_e/infrastructure/withings_oauth_helper.py
@@ -9,6 +9,7 @@ from pydantic import SecretStr
 from urllib.parse import urlencode
 
 from pete_e.config import settings
+from pete_e.infrastructure.log_utils import log_message
 def _unwrap_secret(value):
     if isinstance(value, SecretStr):
         return value.get_secret_value()
@@ -49,6 +50,11 @@ def exchange_code_for_tokens(code: str):
     # Save to file
     with open(TOKEN_FILE, "w") as f:
         json.dump(tokens, f, indent=2)
+    # Lock down permissions to avoid leaking OAuth credentials.
+    try:
+        os.chmod(TOKEN_FILE, 0o600)
+    except OSError as exc:
+        log_message(f"Could not set permissions on {TOKEN_FILE}: {exc}", "WARN")
 
     return tokens
 

--- a/tests/test_withings_token_permissions.py
+++ b/tests/test_withings_token_permissions.py
@@ -1,0 +1,42 @@
+import os
+
+import pytest
+
+from pete_e.infrastructure import withings_oauth_helper as oauth_helper
+from pete_e.infrastructure.withings_client import WithingsClient
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file permissions only")
+def test_save_tokens_sets_owner_only_permissions(tmp_path, monkeypatch):
+    token_path = tmp_path / ".withings_tokens.json"
+    monkeypatch.setattr(WithingsClient, "TOKEN_FILE", token_path)
+
+    client = WithingsClient()
+    client._save_tokens({"access_token": "abc", "refresh_token": "def"})
+
+    mode = token_path.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file permissions only")
+def test_oauth_helper_sets_owner_only_permissions(tmp_path, monkeypatch):
+    token_path = tmp_path / ".withings_tokens.json"
+    monkeypatch.setattr(oauth_helper, "TOKEN_FILE", token_path)
+
+    class DummyResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"status": 0, "body": {"access_token": "abc", "refresh_token": "def"}}
+
+    monkeypatch.setattr(oauth_helper.requests, "post", lambda *_, **__: DummyResponse())
+
+    tokens = oauth_helper.exchange_code_for_tokens("code")
+
+    assert tokens["access_token"] == "abc"
+    assert tokens["refresh_token"] == "def"
+    mode = token_path.stat().st_mode & 0o777
+    assert mode == 0o600


### PR DESCRIPTION
## Summary
- restrict Withings token persistence to owner-only permissions in both the API client and OAuth helper
- cover the behaviour with pytest cases that check file modes
- document that refreshed tokens are stored with chmod 600 permissions

## Testing
- pytest tests/test_withings_token_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_68d1356f431c832fbb73d2cabb9faf17