### PR TITLE
Add lift code mapping for main lifts

### DIFF
--- a/pete_e/domain/schedule_rules.py
+++ b/pete_e/domain/schedule_rules.py
@@ -8,6 +8,14 @@ BENCH_ID = 73
 DEADLIFT_ID = 184
 OHP_ID = 566
 
+# Mapping of main lift exercise IDs to plan builder lift codes
+LIFT_CODE_BY_ID = {
+    SQUAT_ID: "squat",
+    BENCH_ID: "bench",
+    DEADLIFT_ID: "deadlift",
+    OHP_ID: "ohp",
+}
+
 # Blaze is a fixed HIIT class logged as this id
 BLAZE_ID = 1630
 


### PR DESCRIPTION
## Summary
- add a dictionary mapping main lift IDs to lift code strings for plan builder lookups

## Testing
- pytest *(fails: missing optional dependencies such as dropbox, psycopg, typer, requests)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c2ff5978832fa4458f42f82b67f9