### PR TITLE
Extend FakeDal for calibration

### DIFF
--- a/tests/test_cycle_rollover.py
+++ b/tests/test_cycle_rollover.py
@@ -53,6 +53,12 @@ class FakeDal:
     def find_plan_by_start_date(self, start_date: date):
         return self._plans_by_start.get(start_date)
 
+    def get_plan_week(self, plan_id: int, week_number: int):
+        return []
+
+    def update_workout_targets(self, updates):
+        return None
+
     def get_active_plan(self):
         if not self._plans_by_start:
             return None


### PR DESCRIPTION
## Summary
- add calibration-related stubs to the FakeDal used in cycle rollover tests

## Testing
- pytest tests/test_cycle_rollover.py *(fails: missing psycopg dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c924efac832f8b0b08c4680cac22