### PR TITLE
Schedule strength tests on a 13-week cadence

### DIFF
--- a/pete_e/infrastructure/plan_rw.py
+++ b/pete_e/infrastructure/plan_rw.py
@@ -15,7 +15,7 @@ import os
 import json
 import hashlib
 from contextlib import contextmanager
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import psycopg
@@ -55,6 +55,25 @@ def latest_training_max() -> Dict[str, Optional[float]]:
         for row in cur.fetchall():
             out[row["lift_code"]] = row["tm_kg"]
     return out
+
+
+def latest_training_max_date() -> Optional[date]:
+    """Return the most recent date a training max was recorded."""
+
+    sql = "SELECT MAX(measured_at) AS latest FROM training_max;"
+    with conn_cursor() as (_, cur):
+        cur.execute(sql)
+        row = cur.fetchone()
+        if not row:
+            return None
+
+        latest = row.get("latest")
+        if latest is None:
+            return None
+
+        if isinstance(latest, datetime):
+            return latest.date()
+        return latest
 
 
 def assistance_pool_for(main_exercise_id: int) -> List[int]:


### PR DESCRIPTION
## Summary
- add a low-level helper to retrieve the most recent training max measurement date
- update cycle generation to trigger a strength test when the 13-week interval since the last test elapses
- extend the rollover tests to cover the new cadence and stub the training max date lookup

## Testing
- pytest tests/test_cycle_rollover.py -k strength_test_every_thirteen_weeks -vv *(fails: psycopg dependency is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e40b1954832fbb39428d847373f8