### PR TITLE
Fix Telegram strength test trigger

### DIFF
--- a/pete_e/application/telegram_listener.py
+++ b/pete_e/application/telegram_listener.py
@@ -53,7 +53,7 @@ class _OrchestratorProtocol(Protocol):
     def run_end_to_end_day(self, *, days: int = 1):
         ...
 
-    def generate_strength_test_week(self) -> None:
+    def generate_strength_test_week(self) -> bool:
         ...
 
 
@@ -158,18 +158,23 @@ class TelegramCommandListener:
         )
 
     def _handle_lets_begin(self) -> str:
+        success = False
         try:
-            self._get_orchestrator().generate_strength_test_week()
+            success = bool(self._get_orchestrator().generate_strength_test_week())
         except Exception as exc:  # pragma: no cover - defensive guardrail
             log_utils.log_message(
                 f"Strength test week scheduling failed: {exc}",
                 "ERROR",
             )
-            return "Strength test week scheduling failed; check logs."
+            success = False
 
-        confirmation = "Strength test week scheduled"
-        telegram_sender.send_alert(confirmation)
-        return confirmation
+        if success:
+            confirmation = "Strength test week scheduled"
+            telegram_sender.send_alert(confirmation)
+            return confirmation
+
+        failure_message = "Strength test week scheduling failed; check logs."
+        return failure_message
 
     def _extract_command(self, text: str) -> Optional[str]:
         stripped = text.strip()


### PR DESCRIPTION
## Summary
- add an orchestrator helper that builds, activates, and exports a strength test plan with error handling
- update the Telegram listener to rely on the orchestrator result and send success/failure responses accordingly

## Testing
- pytest tests/test_strength_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d53a512b14832f86d2b836184239f1