### PR TITLE
Centralize environment configuration access

### DIFF
--- a/pete_e/application/wger_sync.py
+++ b/pete_e/application/wger_sync.py
@@ -5,7 +5,6 @@ Fetch the Wger exercise catalog and upsert it into the PostgreSQL database.
 Also seeds the main lifts and assistance pools after the catalog is refreshed.
 """
 import logging
-import os
 import sys
 from typing import Any, Dict, List, Optional
 
@@ -13,12 +12,13 @@ import requests
 from pete_e.infrastructure.database import get_conn
 from pete_e.infrastructure.wger_seeder import WgerSeeder
 from pete_e.infrastructure.wger_writer import WgerWriter
+from pete_e.config import get_env, settings
 
 # British English comments and docstrings.
 
 logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s: %(message)s")
 
-BASE = (os.environ.get("WGER_BASE_URL") or "https://wger.de/api/v2").strip().rstrip("/")
+BASE = str(get_env("WGER_BASE_URL", default=settings.WGER_BASE_URL)).strip().rstrip("/")
 
 
 def fetch_all_pages(url: str, params: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:

--- a/pete_e/config/__init__.py
+++ b/pete_e/config/__init__.py
@@ -1,6 +1,6 @@
 # (Functional) Initializes config package (imports Settings instance)
 
-from .config import Settings, settings
+from .config import Settings, get_env, settings
 
-__all__ = ["Settings", "settings"]
+__all__ = ["Settings", "settings", "get_env"]
 

--- a/pete_e/infrastructure/db_conn.py
+++ b/pete_e/infrastructure/db_conn.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+from pete_e.config import get_env
 
 
 def get_database_url() -> str:
@@ -15,15 +15,9 @@ def get_database_url() -> str:
     string, keeping failure modes explicit.
     """
 
-    env_url = os.getenv("DATABASE_URL")
-    if env_url:
-        return env_url
-
-    from pete_e.config.config import settings
-
-    settings_url = settings.DATABASE_URL
-    if settings_url:
-        return settings_url
+    url = get_env("DATABASE_URL")
+    if url:
+        return str(url)
 
     raise RuntimeError(
         "Database connection information is missing. Set the DATABASE_URL "

--- a/pete_e/infrastructure/wger_client.py
+++ b/pete_e/infrastructure/wger_client.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List
 
 import requests
 
-from pete_e.config import settings
+from pete_e.config import get_env
 from pete_e.infrastructure.log_utils import log_message
 
 
@@ -40,10 +40,10 @@ class WgerClient:
         token: str | None = None,
         timeout: int = 30,
     ) -> None:
-        resolved_base = base_url or getattr(settings, "WGER_BASE_URL", "https://wger.de/api/v2")
+        resolved_base = base_url or str(get_env("WGER_BASE_URL", default="https://wger.de/api/v2"))
         self.base_url = resolved_base.rstrip("/")
 
-        resolved_token = token or _resolve_secret(getattr(settings, "WGER_API_KEY", None))
+        resolved_token = token or _resolve_secret(get_env("WGER_API_KEY"))
         self.api_key = resolved_token.strip()
         self.timeout = timeout
 

--- a/pete_e/logging_setup.py
+++ b/pete_e/logging_setup.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
 import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
 
-from pete_e.config import settings
+from pete_e.config import get_env, settings
 
 LOGGER_NAME = "pete_e.history"
 DEFAULT_MAX_BYTES = 5 * 1024 * 1024  # 5 MB per log file
@@ -24,7 +23,7 @@ _configured: bool = False
 def _resolve_level(level: Optional[str]) -> int:
     """Translate a textual level into the numeric value logging expects."""
 
-    candidate = str(level or os.getenv(LOG_LEVEL_ENV_VAR, "INFO")).upper()
+    candidate = str(level or get_env(LOG_LEVEL_ENV_VAR, default=settings.PETE_LOG_LEVEL)).upper()
     numeric_level = logging.getLevelName(candidate)
     if isinstance(numeric_level, int):
         return numeric_level

--- a/scripts/catalog_refresh.py
+++ b/scripts/catalog_refresh.py
@@ -4,7 +4,6 @@
 Fetch the Wger exercise catalog and upsert it into the PostgreSQL database.
 This script replaces the previous file-based caching mechanism.
 """
-import os
 import sys
 from typing import Any, Dict, List, Optional
 import requests
@@ -12,8 +11,9 @@ import requests
 # NOTE: Adjust this import path if your project structure is different.
 # This path assumes a 'pete_e' source root.
 from pete_e.infrastructure.postgres_dal import PostgresDal
+from pete_e.config import get_env, settings
 
-BASE = (os.environ.get("WGER_BASE_URL") or "https://wger.de/api/v2").strip().rstrip("/")
+BASE = str(get_env("WGER_BASE_URL", default=settings.WGER_BASE_URL)).strip().rstrip("/")
 
 def fetch_all(url: str, params: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
     """Fetch all pages of results from a Wger API endpoint."""


### PR DESCRIPTION
## Summary
- add a shared `get_env` helper in the configuration package with defaults for log level and Wger toggles
- switch database utilities, logging, Wger integrations, and scripts to use the centralized accessor instead of direct `os.getenv`

## Testing
- `pytest tests/test_check_auth.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68d9a5e10f90832f84dbb91b1e1b3cd8