### PR TITLE
Fix double escaping in Telegram listener responses

### DIFF
--- a/pete_e/application/telegram_listener.py
+++ b/pete_e/application/telegram_listener.py
@@ -247,8 +247,7 @@ class TelegramCommandListener:
                 )
                 response_text = "Command failed; check logs."
 
-            escaped = telegram_sender.escape_markdown_v2(response_text)
-            if not telegram_sender.send_message(escaped):
+            if not telegram_sender.send_message(response_text):
                 log_utils.log_message(
                     f"Telegram listener failed to reply to {command}.",
                     "ERROR",

--- a/tests/test_telegram_listener.py
+++ b/tests/test_telegram_listener.py
@@ -110,8 +110,8 @@ def test_listen_once_runs_sync_and_reports_status(tmp_path: Path, monkeypatch: p
     assert processed == 1
     assert len(captured) == 1
     assert "Sync result" in captured[0]
-    assert "ingest\\_success: True" in captured[0]
-    assert "summary\\_sent: True" in captured[0]
+    assert "ingest_success: True" in captured[0]
+    assert "summary_sent: True" in captured[0]
     stored = json.loads((tmp_path / "offset.json").read_text())
     assert stored["last_update_id"] == 77
 
@@ -140,12 +140,6 @@ def test_listen_once_triggers_strength_test_week(tmp_path: Path, monkeypatch: py
         "send_alert",
         lambda message: alerts.append(message) or True,
     )
-    monkeypatch.setattr(
-        telegram_listener.telegram_sender,
-        "escape_markdown_v2",
-        lambda message: message,
-    )
-
     orchestration_calls: dict[str, int] = {"generate": 0}
     factory_calls: list[object] = []
 


### PR DESCRIPTION
## Summary
- send telegram listener command responses directly to the sender so Markdown escaping only happens once
- update listener tests to reflect the unescaped payloads and drop the redundant escape stub

## Testing
- pytest tests/test_telegram_listener.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dcd7f1da00832f8707fe81fa5b24a4