### PR TITLE
Send Telegram messages without Markdown formatting

### DIFF
--- a/pete_e/infrastructure/weekly_reviewer.py
+++ b/pete_e/infrastructure/weekly_reviewer.py
@@ -49,7 +49,6 @@ from pete_e.domain.schedule_rules import SQUAT_ID, BENCH_ID, DEADLIFT_ID, OHP_ID
 # Note: you've overwritten v3 with the new implementation, so keep this import path.
 from pete_e.infrastructure.wger_exporter import export_week_to_wger
 from pete_e.config import get_env, settings
-from pete_e.infrastructure.telegram_sender import escape_markdown_v2
 
 MAIN_LIFTS = (SQUAT_ID, BENCH_ID, DEADLIFT_ID, OHP_ID)
 
@@ -394,8 +393,7 @@ def review_and_apply(today: Optional[date] = None, refresh_mvs: bool = True) -> 
         f"Set multiplier {decision.set_multiplier:.2f}, RIR delta {decision.rir_delta:+.1f}, intensity delta {decision.intensity_delta_abs:+.1f} percent on main lifts.",
         f"Window reviewed {inputs.last_week_start} to {inputs.last_week_end}.",
     ] + decision.reasons
-    safe_lines = [escape_markdown_v2(line) for line in summary_lines]
-    _post_telegram("\n".join(safe_lines))
+    _post_telegram("\n".join(summary_lines))
 
     export_status = "dry-run" if dry_run else ("ok" if export_res else "logged")
     return {

--- a/tests/test_message_formatting.py
+++ b/tests/test_message_formatting.py
@@ -150,7 +150,7 @@ def test_daily_summary_formats_extended_metrics(fixed_random, monkeypatch):
     assert bullet_lines == expected_lines
 
 
-def test_send_message_escapes_markdown_v2(monkeypatch):
+def test_send_message_sends_plain_text(monkeypatch):
     payload = {}
 
     def fake_post(url, *, json, timeout):
@@ -170,5 +170,4 @@ def test_send_message_escapes_markdown_v2(monkeypatch):
     text = "Weight: 80.5kg (PR #1)! Gains + smiles."
     assert telegram_sender.send_message(text) is True
 
-    assert payload["json"]["parse_mode"] == "MarkdownV2"
-    assert payload["json"]["text"] == r"Weight: 80\.5kg \(PR \#1\)\! Gains \+ smiles\."
+    assert payload["json"] == {"chat_id": "chat-42", "text": text}


### PR DESCRIPTION
## Summary
- remove markdown escaping logic from the Telegram sender so messages are posted as plain text
- stop the weekly reviewer from escaping Telegram output and rely on raw text
- update the message formatting test to reflect the plain text payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de0173a4e8832fb5b194df2c872e72