### PR TITLE
Fix Wger sets-config payload

### DIFF
--- a/pete_e/infrastructure/wger_exporter.py
+++ b/pete_e/infrastructure/wger_exporter.py
@@ -281,10 +281,16 @@ class WgerClient:
         # The 'step' parameter defaults to "na" when omitted or unsupported, so we
         # explicitly set it to "na" here.  Repeat=True applies the rule to all
         # subsequent iterations.
+        #
+        # NOTE: the Wger API validates ``value`` as a decimal string, not an
+        # integer.  Prior versions sent an int which triggered a HTTP 400
+        # validation error when exporting plans.  Converting to ``str`` keeps the
+        # request schema consistent with the repetitions endpoint and unblocks
+        # plan exports.
         payload = {
             "slot_entry": slot_entry_id,
             "iteration": 1,
-            "value": int(sets),
+            "value": str(int(sets)),
             "operation": "r",
             "step": "na",
             "repeat": True,

--- a/tests/test_wger_exporter.py
+++ b/tests/test_wger_exporter.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pete_e.infrastructure import wger_exporter
+
+
+def test_set_sets_posts_string_payload(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_post(self, path, payload):  # type: ignore[override]
+        captured["path"] = path
+        captured["payload"] = payload
+        return {}
+
+    monkeypatch.setattr(wger_exporter.WgerClient, "post", fake_post, raising=False)
+
+    client = wger_exporter.WgerClient(base_url="https://example.com", token="dummy-token")
+    client.set_sets(slot_entry_id=321, sets=5)
+
+    assert captured["path"] == "/api/v2/sets-config/"
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert payload["slot_entry"] == 321
+    assert payload["value"] == "5"
+


### PR DESCRIPTION
## Summary
- send sets-config values as strings to satisfy Wger's validation rules and prevent 400 errors during plan export
- add a regression test that ensures the exporter posts the corrected payload format

## Testing
- pytest tests/test_wger_exporter.py

------
https://chatgpt.com/codex/tasks/task_e_68e2dcc78ca4832fa85aca16b6eada73