### PR TITLE
Refactor shared utilities into pete_e.utils

### DIFF
--- a/pete_e/utils/__init__.py
+++ b/pete_e/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Shared utility helpers for Pete-E."""
+
+from . import converters, formatters, helpers, math
+
+__all__ = ["converters", "formatters", "helpers", "math"]

--- a/pete_e/utils/converters.py
+++ b/pete_e/utils/converters.py
@@ -1,0 +1,57 @@
+"""Type conversion helpers used across the Pete-E codebase."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, Optional
+
+
+def to_float(value: Any) -> Optional[float]:
+    """Safely convert ``value`` to ``float`` where possible."""
+
+    if value is None:
+        return None
+    if isinstance(value, float):
+        return value
+    if isinstance(value, (int, Decimal)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def to_date(value: Any) -> Optional[date]:
+    """Best-effort conversion of common date representations to ``date``."""
+
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return date.fromisoformat(stripped[:10])
+        except ValueError:
+            return None
+    return None
+
+
+def minutes_to_hours(value: Any) -> Optional[float]:
+    """Convert a minutes value into hours when possible."""
+
+    numeric = to_float(value)
+    if numeric is None:
+        return None
+    return numeric / 60.0

--- a/pete_e/utils/formatters.py
+++ b/pete_e/utils/formatters.py
@@ -1,0 +1,14 @@
+"""Text formatting helpers."""
+
+from __future__ import annotations
+
+
+def ensure_sentence(text: str) -> str:
+    """Ensure ``text`` ends with a sentence terminator when non-empty."""
+
+    body = (text or "").strip()
+    if not body:
+        return body
+    if body[-1] not in ".!?":
+        body = f"{body}."
+    return body

--- a/pete_e/utils/helpers.py
+++ b/pete_e/utils/helpers.py
@@ -1,0 +1,17 @@
+"""General helper utilities shared across Pete-E."""
+
+from __future__ import annotations
+
+import random
+from typing import List
+
+
+def choose_from(options: List[str], default: str = "") -> str:
+    """Return a random element from ``options`` or ``default`` when empty."""
+
+    if not options:
+        return default
+    try:
+        return random.choice(options)
+    except IndexError:
+        return default or options[0]

--- a/pete_e/utils/math.py
+++ b/pete_e/utils/math.py
@@ -1,0 +1,31 @@
+"""Numeric helpers shared across Pete-E modules."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+def average(values: Iterable[Optional[float]]) -> Optional[float]:
+    """Compute the mean of ``values`` while skipping ``None`` entries."""
+
+    filtered = [value for value in values if value is not None]
+    if not filtered:
+        return None
+    return sum(filtered) / len(filtered)
+
+
+def mean_or_none(values: Iterable[float]) -> Optional[float]:
+    """Return the arithmetic mean of ``values`` or ``None`` when empty."""
+
+    values_list = list(values)
+    if not values_list:
+        return None
+    return sum(values_list) / len(values_list)
+
+
+def near(value: float | None, target: float | None, *, tolerance: float = 1e-6) -> bool:
+    """Return ``True`` when ``value`` is within ``tolerance`` of ``target``."""
+
+    if value is None or target is None:
+        return False
+    return abs(value - target) <= tolerance


### PR DESCRIPTION
## Summary
- add a pete_e.utils package with converters, math, formatters, and helpers modules to centralise common helpers
- update body age, progression, French trainer, metrics, and validation code to use the shared converters and math utilities
- remove duplicated helper implementations from domain modules in favour of the new shared utilities

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68e4887c5f44832f8fd4f61e7d855cee