### PR TITLE
Allow choose_from to accept injected RNG

### DIFF
--- a/pete_e/domain/narrative_builder.py
+++ b/pete_e/domain/narrative_builder.py
@@ -313,7 +313,11 @@ def _to_int(value: Any) -> int | None:
 def _format_daily_heading(day_value: date | None) -> str:
     if day_value is None:
         return "*Daily Flex*"
-    template = helpers.choose_from(_DAILY_HEADINGS, "*{weekday} {day} {month}: Daily Flex*")
+    template = helpers.choose_from(
+        _DAILY_HEADINGS,
+        "*{weekday} {day} {month}: Daily Flex*",
+        rand=random,
+    )
     context = {
         "weekday": day_value.strftime("%A"),
         "day": day_value.strftime("%d"),
@@ -653,7 +657,11 @@ def _format_environment_line(summary_data: Dict[str, Any]) -> str | None:
 
 def _no_daily_metrics_message() -> str:
     message = CoachMessage(
-        greeting=helpers.choose_from(_COACH_GREETINGS, "Coach Pete checking in"),
+        greeting=helpers.choose_from(
+            _COACH_GREETINGS,
+            "Coach Pete checking in",
+            rand=random,
+        ),
         heading="*Daily Flex*",
         bullets=["- No fresh metrics landed – give your trackers a sync and shout me once it's in."],
         closers=_closing_phrases(["#Consistency"], "Consistency is queen, volume is king!"),
@@ -672,7 +680,11 @@ def _clean_number(raw: Any) -> str:
 def _format_weekly_heading(week_number: int, week_start: date | None) -> str:
     if week_start is None:
         return f"*Week {week_number} Game Plan*"
-    template = helpers.choose_from(_WEEKLY_HEADINGS, "*Week {week} Game Plan · {start} → {end}*")
+    template = helpers.choose_from(
+        _WEEKLY_HEADINGS,
+        "*Week {week} Game Plan · {start} → {end}*",
+        rand=random,
+    )
     week_end = week_start + timedelta(days=6)
     return template.format(
         week=week_number,
@@ -728,7 +740,11 @@ def _format_rest_line(rest_days: List[str]) -> str | None:
 
 def _no_plan_message(week_number: int) -> str:
     message = CoachMessage(
-        greeting=helpers.choose_from(_COACH_WEEKLY_GREETINGS, "Coach Pete here"),
+        greeting=helpers.choose_from(
+            _COACH_WEEKLY_GREETINGS,
+            "Coach Pete here",
+            rand=random,
+        ),
         heading=f"*Week {week_number} Game Plan*",
         bullets=["- I couldn't find workouts for this week – ping me once the plan's loaded."],
         closers=_closing_phrases(["#Motivation"], "We'll build the week the moment data lands."),
@@ -1027,7 +1043,11 @@ def build_weekly_plan_summary(
     )
 
     message = CoachMessage(
-        greeting=helpers.choose_from(_COACH_WEEKLY_GREETINGS, "Coach Pete here"),
+        greeting=helpers.choose_from(
+            _COACH_WEEKLY_GREETINGS,
+            "Coach Pete here",
+            rand=random,
+        ),
         heading=_format_weekly_heading(week_number, week_start),
         bullets=bullets,
         narrative=[],
@@ -1137,7 +1157,11 @@ class NarrativeBuilder:
         )
 
         message = CoachMessage(
-            greeting=helpers.choose_from(_COACH_GREETINGS, "Coach Pete checking in"),
+            greeting=helpers.choose_from(
+                _COACH_GREETINGS,
+                "Coach Pete checking in",
+                rand=random,
+            ),
             heading=heading,
             bullets=bullet_lines,
             narrative=narrative,

--- a/pete_e/utils/helpers.py
+++ b/pete_e/utils/helpers.py
@@ -6,12 +6,13 @@ import random
 from typing import List
 
 
-def choose_from(options: List[str], default: str = "") -> str:
+def choose_from(options: List[str], default: str = "", rand=None) -> str:
     """Return a random element from ``options`` or ``default`` when empty."""
 
+    rng = rand or random
     if not options:
         return default
     try:
-        return random.choice(options)
+        return rng.choice(options)
     except IndexError:
         return default or options[0]


### PR DESCRIPTION
## Summary
- allow `helpers.choose_from` to accept an optional random generator so callers can control determinism
- ensure narrative builder calls pass their local `random` module so monkeypatched RNGs propagate to helper usage

## Testing
- pytest tests/test_message_formatting.py::test_daily_summary_uses_coach_voice tests/test_message_snapshots.py::test_daily_message_snapshot tests/test_weekly_plan_message.py::test_weekly_plan_cli_formats_overview tests/test_weekly_plan_message.py::test_weekly_plan_cli_send_uses_formatted_overview *(fails: missing rich dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e491a11c3c832f84ce6f142fde1ed7