### PR TITLE
Add reusable DAL test stubs

### DIFF
--- a/tests/config_stub.py
+++ b/tests/config_stub.py
@@ -1,0 +1,40 @@
+"""Provide a minimal pete_e.config stub for tests."""
+from __future__ import annotations
+
+import sys
+import types
+from datetime import date
+from pathlib import Path
+
+
+if "pete_e.config" not in sys.modules:
+    config_module = types.ModuleType("pete_e.config")
+
+    class _SettingsStub:
+        USER_DATE_OF_BIRTH = date(1990, 1, 1)
+        DATABASE_URL = "postgresql://stub"
+        BASELINE_DAYS = 28
+        PROGRESSION_INCREMENT = 0.05
+        PROGRESSION_DECREMENT = 0.05
+        RHR_ALLOWED_INCREASE = 0.10
+        SLEEP_ALLOWED_DECREASE = 0.85
+        HRV_ALLOWED_DECREASE = 0.12
+        BODY_AGE_ALLOWED_INCREASE = 2.0
+        GLOBAL_BACKOFF_FACTOR = 0.90
+        CYCLE_DAYS = 28
+
+        def __getattr__(self, name):  # pragma: no cover - defensive default
+            return None
+
+        @property
+        def log_path(self):  # pragma: no cover - ensure log path is writable
+            return Path("logs/test.log")
+
+    config_module.settings = _SettingsStub()
+    config_module.get_env = lambda key, default=None: default
+    sys.modules["pete_e.config"] = config_module
+
+    config_submodule = types.ModuleType("pete_e.config.config")
+    config_submodule.settings = config_module.settings
+    config_submodule.get_env = config_module.get_env
+    sys.modules["pete_e.config.config"] = config_submodule

--- a/tests/mock_dal.py
+++ b/tests/mock_dal.py
@@ -1,0 +1,177 @@
+"""Utilities for constructing DataAccessLayer test doubles."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from pete_e.domain.data_access import DataAccessLayer
+
+
+class MockableDal(DataAccessLayer):
+    """Concrete DataAccessLayer with inert implementations.
+
+    Tests can subclass this base and override only the behaviours that are
+    relevant for the scenario under test. All other methods intentionally do
+    nothing (or return empty placeholders) so that simple stubs automatically
+    satisfy the interface even as it grows optional surface area.
+    """
+
+    # ------------------------------------------------------------------
+    # Source saves
+    # ------------------------------------------------------------------
+    def save_withings_daily(
+        self,
+        day: date,
+        weight_kg: Optional[float],
+        body_fat_pct: Optional[float],
+        muscle_pct: Optional[float],
+        water_pct: Optional[float],
+    ) -> None:
+        pass
+
+    def save_wger_log(
+        self,
+        day: date,
+        exercise_id: int,
+        set_number: int,
+        reps: int,
+        weight_kg: Optional[float],
+        rir: Optional[float],
+    ) -> None:
+        pass
+
+    def load_lift_log(
+        self,
+        exercise_ids: Optional[List[int]] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+    ) -> Dict[str, Any]:
+        return {}
+
+    # ------------------------------------------------------------------
+    # Summaries (read-only views)
+    # ------------------------------------------------------------------
+    def get_daily_summary(self, target_date: date) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_historical_metrics(self, days: int) -> List[Dict[str, Any]]:
+        return []
+
+    def get_historical_data(
+        self, start_date: date, end_date: date
+    ) -> List[Dict[str, Any]]:
+        return []
+
+    def refresh_daily_summary(self, days: int = 7) -> None:
+        pass
+
+    def compute_body_age_for_date(
+        self,
+        target_date: date,
+        *,
+        birth_date: date,
+    ) -> None:
+        pass
+
+    def compute_body_age_for_range(
+        self,
+        start_date: date,
+        end_date: date,
+        *,
+        birth_date: date,
+    ) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Training plans
+    # ------------------------------------------------------------------
+    def save_training_plan(self, plan: dict, start_date: date) -> int:
+        return 0
+
+    def has_any_plan(self) -> bool:
+        return False
+
+    def get_plan(self, plan_id: int) -> Dict[str, Any]:
+        return {}
+
+    def find_plan_by_start_date(
+        self, start_date: date
+    ) -> Optional[Dict[str, Any]]:
+        return None
+
+    def mark_plan_active(self, plan_id: int) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Muscle volume comparison
+    # ------------------------------------------------------------------
+    def get_plan_muscle_volume(
+        self, plan_id: int, week_number: int
+    ) -> List[Dict[str, Any]]:
+        return []
+
+    def get_actual_muscle_volume(
+        self, start_date: date, end_date: date
+    ) -> List[Dict[str, Any]]:
+        return []
+
+    # ------------------------------------------------------------------
+    # Active plan and plan weeks
+    # ------------------------------------------------------------------
+    def get_active_plan(self) -> Optional[Dict[str, Any]]:
+        return None
+
+    def get_plan_week(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:
+        return []
+
+    def update_workout_targets(self, updates: List[Dict[str, Any]]) -> None:
+        pass
+
+    def refresh_plan_view(self) -> None:
+        pass
+
+    def refresh_actual_view(self) -> None:
+        pass
+
+    def apply_plan_backoff(
+        self,
+        week_start_date: date,
+        *,
+        set_multiplier: float,
+        rir_increment: int,
+    ) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Wger Catalog Upserts
+    # ------------------------------------------------------------------
+    def upsert_wger_categories(self, categories: List[Dict[str, Any]]) -> None:
+        pass
+
+    def upsert_wger_equipment(self, equipment: List[Dict[str, Any]]) -> None:
+        pass
+
+    def upsert_wger_muscles(self, muscles: List[Dict[str, Any]]) -> None:
+        pass
+
+    def upsert_wger_exercises(self, exercises: List[Dict[str, Any]]) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Validation logs
+    # ------------------------------------------------------------------
+    def save_validation_log(self, tag: str, adjustments: List[str]) -> None:
+        pass
+
+    def was_week_exported(self, plan_id: int, week_number: int) -> bool:
+        return False
+
+    def record_wger_export(
+        self,
+        plan_id: int,
+        week_number: int,
+        payload: Dict[str, Any],
+        response: Optional[Dict[str, Any]] = None,
+        routine_id: Optional[int] = None,
+    ) -> None:
+        pass

--- a/tests/rich_stub.py
+++ b/tests/rich_stub.py
@@ -1,0 +1,50 @@
+"""Provide a light-weight stub for the rich library used in tests."""
+from __future__ import annotations
+
+import sys
+import types
+
+
+if "rich.console" not in sys.modules:
+    rich_module = types.ModuleType("rich")
+    console_module = types.ModuleType("rich.console")
+    table_module = types.ModuleType("rich.table")
+    text_module = types.ModuleType("rich.text")
+
+    class _Console:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+            pass
+
+        def print(self, *args, **kwargs):  # pragma: no cover - mimic Console API
+            pass
+
+    console_module.Console = _Console
+    rich_module.console = console_module
+
+    class _Table:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+            pass
+
+        def add_column(self, *args, **kwargs):  # pragma: no cover - mimic API
+            pass
+
+        def add_row(self, *args, **kwargs):  # pragma: no cover - mimic API
+            pass
+
+    table_module.Table = _Table
+    rich_module.table = table_module
+
+    class _Text:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+            pass
+
+        def append(self, *args, **kwargs):  # pragma: no cover - mimic API
+            pass
+
+    text_module.Text = _Text
+    rich_module.text = text_module
+
+    sys.modules["rich"] = rich_module
+    sys.modules["rich.console"] = console_module
+    sys.modules["rich.table"] = table_module
+    sys.modules["rich.text"] = text_module

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -6,27 +6,8 @@ import os
 
 import pytest
 
-
-if "pete_e.config" not in sys.modules:
-    config_stub = types.ModuleType("pete_e.config")
-
-    class _SettingsStub:
-        USER_DATE_OF_BIRTH = date(1990, 1, 1)
-        DATABASE_URL = "postgresql://stub"
-
-        def __getattr__(self, name):  # pragma: no cover - defensive default
-            return None
-
-        @property
-        def log_path(self):  # pragma: no cover - ensure log path is writable
-            return Path("logs/test.log")
-
-    config_stub.settings = _SettingsStub()
-    sys.modules["pete_e.config"] = config_stub
-
-    config_config_stub = types.ModuleType("pete_e.config.config")
-    config_config_stub.settings = config_stub.settings
-    sys.modules["pete_e.config.config"] = config_config_stub
+from tests import config_stub, rich_stub  # noqa: F401 - ensure dependencies are stubbed
+from tests.mock_dal import MockableDal
 
 if "pete_e.data_access.postgres_dal" not in sys.modules:
     postgres_stub = types.ModuleType("pete_e.data_access.postgres_dal")
@@ -44,7 +25,7 @@ from pete_e.application.orchestrator import Orchestrator
 from pete_e.cli import messenger as messenger_module
 
 
-class DummyDal:
+class DummyDal(MockableDal):
     def __init__(self):
         self.withings_calls = []
         self.wger_logs = []
@@ -63,21 +44,6 @@ class DummyDal:
 
     def refresh_daily_summary(self, days: int = 7) -> None:
         self.refreshed = True
-
-    def compute_body_age_for_date(self, target_date: date, *, birth_date: date) -> None:
-        pass
-
-    def compute_body_age_for_range(
-        self,
-        start_date: date,
-        end_date: date,
-        *,
-        birth_date: date,
-    ) -> None:
-        pass
-
-    def mark_plan_active(self, plan_id: int) -> None:
-        pass
 
     def has_any_plan(self) -> bool:
         return True

--- a/tests/test_progression.py
+++ b/tests/test_progression.py
@@ -2,11 +2,17 @@ import datetime
 from typing import Any, Dict, List
 
 from pete_e.domain.progression import apply_progression
-from pete_e.domain.data_access import DataAccessLayer
 from pete_e.config import settings
+from tests import config_stub  # noqa: F401 - ensure pete_e.config is stubbed
+from tests.mock_dal import MockableDal
 
-class DummyDal(DataAccessLayer):
-    def __init__(self, lift_history: Dict[str, Any], metrics_7: List[Dict[str, Any]], metrics_baseline: List[Dict[str, Any]]):
+class DummyDal(MockableDal):
+    def __init__(
+        self,
+        lift_history: Dict[str, Any],
+        metrics_7: List[Dict[str, Any]],
+        metrics_baseline: List[Dict[str, Any]],
+    ) -> None:
         self._lift_history = lift_history
         self._metrics_7 = metrics_7
         self._metrics_baseline = metrics_baseline
@@ -23,27 +29,9 @@ class DummyDal(DataAccessLayer):
             return {k: v for k, v in self._lift_history.items() if k in keys}
         return self._lift_history
 
-    def save_lift_log(self, log: Dict[str, Any]) -> None:
-        pass
-
-    def save_strength_log_entry(self, exercise_id: int, log_date: datetime.date, reps: int, weight_kg: float, rir: float | None = None) -> None:
-        pass
-
-    def save_withings_daily(self, day: datetime.date, weight_kg: float, body_fat_pct: float, muscle_pct: float | None, water_pct: float | None) -> None:
-        pass
-
-    def save_wger_log(self, day: datetime.date, exercise_id: int, set_number: int, reps: int, weight_kg: float | None, rir: float | None) -> None:
-        pass
-
     # History operations
     def load_history(self) -> Dict[str, Any]:
         return {}
-
-    def save_history(self, history: Dict[str, Any]) -> None:
-        pass
-
-    def save_daily_summary(self, summary: Dict[str, Any], day: datetime.date) -> None:
-        pass
 
     # Analytical helpers
     def load_body_age(self) -> Dict[str, Any]:
@@ -56,97 +44,6 @@ class DummyDal(DataAccessLayer):
             return self._metrics_baseline
         return []
 
-    def get_daily_summary(self, target_date: datetime.date) -> Dict[str, Any] | None:
-        return None
-
-    def get_historical_data(self, start_date: datetime.date, end_date: datetime.date) -> List[Dict[str, Any]]:
-        return []
-
-    def save_training_plan(self, plan: dict, start_date: datetime.date) -> None:
-        pass
-
-    def has_any_plan(self) -> bool:
-        return False
-
-    def save_validation_log(self, tag: str, adjustments: List[str]) -> None:
-        pass
-
-    def get_plan(self, plan_id: int) -> Dict[str, Any]:
-        return {}
-
-    def get_plan_muscle_volume(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:
-        return []
-
-    def get_actual_muscle_volume(self, start_date: datetime.date, end_date: datetime.date) -> List[Dict[str, Any]]:
-        return []
-
-    def get_active_plan(self) -> Dict[str, Any] | None:
-        return None
-
-    def get_plan_week(self, plan_id: int, week_number: int) -> List[Dict[str, Any]]:
-        return []
-
-    def update_workout_targets(self, updates: List[Dict[str, Any]]) -> None:
-        pass
-
-    def refresh_plan_view(self) -> None:
-        pass
-
-    def refresh_actual_view(self) -> None:
-        pass
-
-    def apply_plan_backoff(
-        self,
-        week_start_date: datetime.date,
-        *,
-        set_multiplier: float,
-        rir_increment: int,
-    ) -> None:
-        pass
-
-    def mark_plan_active(self, plan_id: int) -> None:
-        pass
-
-    def refresh_daily_summary(self, days: int = 7) -> None:
-        pass
-
-    def compute_body_age_for_date(
-        self,
-        target_date: datetime.date,
-        *,
-        birth_date: datetime.date,
-    ) -> None:
-        pass
-
-    def compute_body_age_for_range(
-        self,
-        start_date: datetime.date,
-        end_date: datetime.date,
-        *,
-        birth_date: datetime.date,
-    ) -> None:
-        pass
-
-    def upsert_wger_categories(self, categories: List[Dict[str, Any]]) -> None:
-        pass
-
-    def upsert_wger_equipment(self, equipment: List[Dict[str, Any]]) -> None:
-        pass
-
-    def upsert_wger_muscles(self, muscles: List[Dict[str, Any]]) -> None:
-        pass
-
-    def upsert_wger_exercises(self, exercises: List[Dict[str, Any]]) -> None:
-        pass
-
-    def find_plan_by_start_date(self, start_date: datetime.date):
-        return None
-
-    def record_wger_export(self, plan_id: int, week: int, exported_at: datetime.datetime | None = None) -> None:
-        pass
-
-    def was_week_exported(self, plan_id: int, week: int) -> bool:
-        return False
 
 def make_metrics(rhr: float, sleep: float, days: int) -> List[Dict[str, Any]]:
     return [


### PR DESCRIPTION
## Summary
- add a `MockableDal` base class that implements Pete-Eebot's DataAccessLayer with no-op behaviours for convenient test doubles
- update orchestrator and progression tests to leverage the reusable DAL base and shared config/rich stubs
- provide lightweight stubs for configuration and `rich` so tests can import orchestrator without external dependencies

## Testing
- pytest tests/test_orchestrator.py tests/test_progression.py

------
https://chatgpt.com/codex/tasks/task_e_68e49a50ed3c832fbd42adbec9c34fa4