### PR TITLE
Document utility layout and usage guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing Guidelines
+
+## Shared Utilities
+
+Pete-E centralises cross-cutting helpers inside `pete_e/utils/`. When adding or updating utilities, follow these conventions:
+
+- **Module layout.** Organise helpers by responsibility: `converters.py` for type conversions, `formatters.py` for text rendering, `math.py` for numeric helpers, and `helpers.py` for miscellaneous glue. Create a new module only when a responsibility does not fit the existing ones.
+- **Import style.** Prefer importing modules explicitly: `from pete_e.utils import converters` and call `converters.to_float(...)`. This keeps call sites clear about a helper's origin and reduces accidental name clashes. Import individual functions only when they are truly ubiquitous and the name is unambiguous.
+- **Naming.** Choose descriptive, singular names (e.g. `to_float`, `to_date`, `minutes_to_hours`). Avoid prefixes such as `_as_*` or suffixes like `_util`; the module name already conveys that these are utilities.
+- **Separation.** Utility code must remain free of application or domain dependencies to prevent circular imports. Rely only on the Python standard library or third-party packages already in use. If a helper requires knowledge of domain concepts, place it in the appropriate `application` or `domain` module instead.
+- **Reusability.** Before introducing a new helper, review the existing modules to avoid duplicating behaviour. Shared improvements belong in `pete_e.utils` so other layers can benefit from them.
+
+Documenting these expectations ensures future contributors extend the utilities consistently and keeps shared helpers easy to discover.

--- a/README.md
+++ b/README.md
@@ -25,19 +25,20 @@ Pete-Eebot is a personal health and fitness orchestrator. The application ingest
 
 ```
 .
-â”œâ”€â”€ pete_e/                 # Python package containing the active application code
-â”‚   â”œâ”€â”€ application/        # Orchestration flows (sync, Dropbox ingest, plan generation)
-â”‚   â”œâ”€â”€ cli/                # Typer-powered command line interface
-â”‚   â”œâ”€â”€ config/             # Environment-driven settings
-â”‚   â”œâ”€â”€ domain/             # Business rules (progression, plans, narratives, analytics)
-â”‚   â”œâ”€â”€ infrastructure/     # DAL, API clients, and integrations
-â”‚   â””â”€â”€ resources/          # Static assets used by the application
-â”œâ”€â”€ scripts/                # One-off helpers for maintenance and reviews
-â”œâ”€â”€ tests/                  # Pytest suite for ingestion, orchestration, and validation logic
-â”œâ”€â”€ docs/                   # Design notes and analytical documentation
-â”œâ”€â”€ deprecated/             # Legacy FastAPI/Tailscale implementation retained for reference
-â”œâ”€â”€ docker-compose.yml      # Local Postgres bootstrap for development
-â””â”€â”€ init-db/                # SQL migrations used by the active schema
+├── pete_e/                 # Python package containing the active application code
+│   ├── application/        # Orchestration flows (sync, Dropbox ingest, plan generation)
+│   ├── cli/                # Typer-powered command line interface
+│   ├── config/             # Environment-driven settings
+│   ├── domain/             # Business rules (progression, plans, narratives, analytics)
+│   ├── infrastructure/     # DAL, API clients, and integrations
+│   ├── resources/          # Static assets used by the application
+│   └── utils/              # Globally reusable converters, formatters, and helpers
+├── scripts/                # One-off helpers for maintenance and reviews
+├── tests/                  # Pytest suite for ingestion, orchestration, and validation logic
+├── docs/                   # Design notes and analytical documentation
+├── deprecated/             # Legacy FastAPI/Tailscale implementation retained for reference
+├── docker-compose.yml      # Local Postgres bootstrap for development
+└── init-db/                # SQL migrations used by the active schema
 ```
 
 ---

--- a/pete_e/README.md
+++ b/pete_e/README.md
@@ -11,3 +11,6 @@ Subfolders:
   - domain/
   - infrastructure/
   - resources/
+  - utils/
+
+    - Shared converters, formatters, math helpers, and miscellaneous utilities. Import modules as ``from pete_e.utils import converters`` to keep call sites explicit.


### PR DESCRIPTION
## Summary
- highlight the pete_e.utils package in the repository layout and package README
- add contributing guidance covering module naming, imports, and dependency rules for shared utilities

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4a8dcf638832f9f3e5ebec82972bb